### PR TITLE
Update3

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install validation tools
       run: |
         sudo apt-get update
-        sudo apt-get install -y shellcheck xmllint
+        sudo apt-get install -y shellcheck libxml2-utils
     
     - name: Validate shell scripts
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -185,7 +185,7 @@ jobs:
         fi
         
         # Check for supported OS versions
-        if grep -q '"22"\|"23"\|"24"' wireless.sh; then
+        if grep -q "22|23|24" wireless.sh; then
           echo "✅ Supported macOS versions defined (Ventura, Sonoma, Sequoia)"
         else
           echo "❌ macOS version support not properly defined"

--- a/README.md
+++ b/README.md
@@ -1,114 +1,115 @@
 # macOS Wireless Auto-Switch
 
-*Automatically manage WiFi connections when wired network is available*
+[![macOS](https://img.shields.io/badge/macOS-Ventura%20|%20Sonoma%20|%20Sequoia-blue?style=flat-square)](https://www.apple.com/macos/)
+[![Bash](https://img.shields.io/badge/Bash-4+-green?style=flat-square)](https://www.gnu.org/software/bash/)
+[![License](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](LICENSE)
 
-[![macOS](https://img.shields.io/badge/macOS-Ventura%20%7C%20Sonoma%20%7C%20Sequoia-blue)](https://www.apple.com/macos/)
-[![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Bash](https://img.shields.io/badge/Bash-4%2B-green)](https://www.gnu.org/software/bash/)
+⭐ If you like this project, star it on GitHub — it helps a lot!
 
 [Features](#features) • [Installation](#installation) • [Usage](#usage) • [How it works](#how-it-works) • [Troubleshooting](#troubleshooting)
 
-A lightweight macOS utility that automatically toggles WiFi off when a wired Ethernet connection is detected, and back on when disconnected. No more manually switching networks or dealing with connection conflicts between wired and wireless interfaces.
+A lightweight macOS utility that automatically toggles WiFi off when a wired Ethernet connection is detected, and back on when disconnected. Perfect for eliminating network conflicts and ensuring optimal connection performance without manual intervention.
 
 ## Features
 
-- **🔄 Automatic WiFi Toggle** - Seamlessly switches WiFi off/on based on wired connection status
-- **⚡ Real-time Detection** - Uses macOS LaunchDaemon for instant network state monitoring
-- **🔌 Multi-adapter Support** - Works with Ethernet, Thunderbolt, LAN, and USB-C adapters (including AX88179A)
-- **🛡️ System Integration** - Runs as a system service with proper permissions and logging
-- **📊 Smart IP Detection** - Ignores loopback and self-assigned addresses for accurate detection
-- **🖥️ Modern macOS Support** - Compatible with Ventura (13.x), Sonoma (14.x), and Sequoia (15.x)
+- **Automatic WiFi Management** - Seamlessly switches WiFi off/on based on wired connection status
+- **Real-time Network Monitoring** - Uses macOS LaunchDaemon for instant network state detection
+- **Multi-adapter Support** - Works with Ethernet, Thunderbolt, LAN, and USB-C adapters (including AX88179A)
+- **System Integration** - Runs as a native macOS system service with proper logging
+- **Smart IP Detection** - Ignores loopback and self-assigned addresses for accurate connection status
+- **Modern macOS Support** - Compatible with Ventura (13.x), Sonoma (14.x), and Sequoia (15.x)
 
 ## Installation
 
 ### Prerequisites
 
 - macOS Ventura (13.x) or later
-- Administrator privileges
-- Bash 4+ (recommended)
+- Administrator privileges for system installation
+- Bash 4+ (included with modern macOS)
 
-### Quick Install
+### Quick Start
 
-1. Clone or download this repository:
+1. Clone the repository:
    ```bash
    git clone https://github.com/locus313/macos-wireless-autoswitch.git
    cd macos-wireless-autoswitch
    ```
 
-2. Run the installation script:
+2. Install the service:
    ```bash
    ./install.sh i
    ```
 
-The installer will:
-- Copy scripts to `/Library/Scripts/NetBasics/`
-- Install the LaunchDaemon configuration
-- Set proper permissions and ownership
-- Start monitoring network changes immediately
+The installer automatically:
+- Copies scripts to `/Library/Scripts/NetBasics/`
+- Installs the LaunchDaemon configuration
+- Sets proper permissions and ownership
+- Starts monitoring network changes immediately
 
 > [!NOTE]
-> The script requires `sudo` privileges to install system-level components.
+> Installation requires `sudo` privileges to create system-level components.
 
 ## Usage
 
 ### Management Commands
 
-The `install.sh` script provides an interactive menu or can be used with direct commands:
+Use the `install.sh` script for all management operations:
 
 ```bash
 # Install the service
 ./install.sh i
 
-# Update to latest version
+# Update to latest version  
 ./install.sh up
 
 # Uninstall completely
 ./install.sh ui
 
-# Interactive menu (default)
+# Interactive menu
 ./install.sh
 ```
 
 ### Verification
 
-After installation, you can verify the service is running:
+After installation, verify the service is working:
 
 ```bash
-# Check if LaunchDaemon is loaded
+# Check LaunchDaemon status
 sudo launchctl list | grep com.computernetworkbasics.wifionoff
 
-# View recent log entries
+# View logs
 log show --predicate 'subsystem == "com.apple.console"' --info --last 1h | grep wireless.sh
 ```
 
 ## How it works
 
-The system consists of three main components:
+The system consists of three components working together:
 
-### 1. Network Detection (`wireless.sh`)
-- Scans for wired network interfaces (Ethernet, LAN, Thunderbolt, AX88179A)
-- Checks for valid IP addresses (excluding loopback and self-assigned)
-- Controls WiFi state using `networksetup -setairportpower`
+### Network Detection Engine (`wireless.sh`)
+- Automatically scans for wired network interfaces using hardware port detection
+- Validates active connections by checking for legitimate IP addresses
+- Controls WiFi state using `networksetup -setairportpower` commands
+- Implements smart filtering to exclude loopback and self-assigned addresses
 
-### 2. System Monitoring (`com.computernetworkbasics.wifionoff.plist`)
-- LaunchDaemon watches `/Library/Preferences/SystemConfiguration` for changes
-- Triggers the wireless script whenever network configuration changes
+### System Monitoring (`com.computernetworkbasics.wifionoff.plist`)
+- LaunchDaemon watches `/Library/Preferences/SystemConfiguration` for network changes
+- Triggers the wireless script whenever network configuration is modified
 - Runs with root privileges for system-level network control
+- Uses throttling to prevent excessive execution during rapid network changes
 
-### 3. Management Interface (`install.sh`)
-- Interactive installation, update, and removal
-- Proper permission setting and system integration
-- Sudo privilege detection and handling
+### Management Interface (`install.sh`)
+- Provides interactive installation, update, and removal capabilities
+- Handles proper permission setting and system integration
+- Includes sudo privilege detection and validation
+- Offers both command-line and menu-driven operation modes
 
-### Network Detection Logic
+### Supported Network Adapters
 
-```bash
-# Example: Check what interfaces are detected
-networksetup -listnetworkserviceorder | grep "Hardware Port" | grep "Ethernet\|LAN\|Thunderbolt\|AX88179A"
-
-# Example: View current WiFi status
-networksetup -getairportpower Wi-Fi
-```
+The utility automatically detects and works with:
+- Built-in Ethernet ports
+- Thunderbolt Ethernet adapters
+- USB-C Ethernet adapters (including AX88179A chipset)
+- Any interface with "LAN" designation
 
 ## Troubleshooting
 
@@ -116,9 +117,6 @@ networksetup -getairportpower Wi-Fi
 
 **WiFi not switching automatically:**
 ```bash
-# Check if LaunchDaemon is running
-sudo launchctl list | grep wifionoff
-
 # Restart the service
 sudo launchctl unload /Library/LaunchDaemons/com.computernetworkbasics.wifionoff.plist
 sudo launchctl load /Library/LaunchDaemons/com.computernetworkbasics.wifionoff.plist
@@ -126,11 +124,11 @@ sudo launchctl load /Library/LaunchDaemons/com.computernetworkbasics.wifionoff.p
 
 **Script not detecting wired connection:**
 ```bash
-# Test interface detection manually
-./wireless.sh
+# Test detection manually
+sudo /Library/Scripts/NetBasics/wireless.sh
 
-# Check system logs for errors
-log show --predicate 'process == "wireless.sh"' --info --last 1h
+# Check available interfaces
+networksetup -listallhardwareports
 ```
 
 **Permission errors:**
@@ -140,44 +138,35 @@ ls -la /Library/Scripts/NetBasics/wireless.sh
 ls -la /Library/LaunchDaemons/com.computernetworkbasics.wifionoff.plist
 ```
 
-### Supported Adapters
-
-The script automatically detects these adapter types:
-- Built-in Ethernet ports
-- Thunderbolt Ethernet adapters
-- USB-C Ethernet adapters (including AX88179A chipset)
-- Any interface with "LAN" in the hardware port name
-
 ### Manual Testing
 
-You can test the core functionality manually:
+Test the core functionality directly:
 
 ```bash
-# Run the detection script directly
+# Run detection script manually
 sudo /Library/Scripts/NetBasics/wireless.sh
 
-# Check what network interfaces are available
-networksetup -listallhardwareports
+# Check current WiFi status
+networksetup -getairportpower Wi-Fi
+
+# List detected wired interfaces
+networksetup -listnetworkserviceorder | grep "Hardware Port" | grep "Ethernet\|LAN\|Thunderbolt\|AX88179A"
 ```
 
-## Uninstallation
+### System Requirements
 
-To completely remove the service:
+- **macOS Version**: Ventura (13.x), Sonoma (14.x), or Sequoia (15.x)
+- **Shell**: Bash 4+ (included with macOS)
+- **Privileges**: Administrator access for installation
+- **Network Stack**: Standard macOS networking components
 
-```bash
-./install.sh ui
-```
+## Authors
 
-This will:
-- Stop and unload the LaunchDaemon
-- Remove all installed files
-- Clean up system configurations
+- **Ryan Lininger** - Original script concept and implementation
+- **locus313** - Modern macOS compatibility, architecture improvements, and maintenance
 
-## Authors & Contributors
+## Resources
 
-- **Ryan Lininger** - Original script author - [Source](https://web.archive.org/web/20180508004545/www.computernetworkbasics.com/2012/12/automatically-turn-off-wireless-in-osx-including-mountain-lion/)
-- **locus313** - Maintenance and modern macOS compatibility
-
-## License
-
-This project is open source and available under the MIT License.
+- [macOS LaunchDaemon Documentation](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html)
+- [NetworkSetup Command Reference](https://ss64.com/osx/networksetup.html)
+- [Original Implementation](https://web.archive.org/web/20180508004545/www.computernetworkbasics.com/2012/12/automatically-turn-off-wireless-in-osx-including-mountain-lion/)

--- a/com.computernetworkbasics.wifionoff.plist
+++ b/com.computernetworkbasics.wifionoff.plist
@@ -1,15 +1,33 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>Label</key>
-<string>com.computernetworkbasics.wifionoff</string>
-<key>ProgramArguments</key>
-<array>
-<string>/Library/Scripts/NetBasics/wireless.sh</string>
-</array>
-<key>WatchPaths</key>
-<array>
-<string>/Library/Preferences/SystemConfiguration</string>
-</array>
+    <key>Label</key>
+    <string>com.computernetworkbasics.wifionoff</string>
+    
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Library/Scripts/NetBasics/wireless.sh</string>
+    </array>
+    
+    <key>WatchPaths</key>
+    <array>
+        <string>/Library/Preferences/SystemConfiguration</string>
+    </array>
+    
+    <key>UserName</key>
+    <string>root</string>
+    
+    <key>StandardOutPath</key>
+    <string>/var/log/wireless-autoswitch.log</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/wireless-autoswitch.log</string>
+    
+    <key>RunAtLoad</key>
+    <false/>
+    <key>KeepAlive</key>
+    <false/>
+    
+    <key>ThrottleInterval</key>
+    <integer>5</integer>
 </dict>
 </plist>

--- a/install.sh
+++ b/install.sh
@@ -1,79 +1,366 @@
 #!/bin/bash
 
-NETBASICS_PATH="/Library/Scripts/NetBasics"
-LAUNCHDAEMONS_PATH="/Library/LaunchDaemons"
+#
+# macOS Wireless Auto-Switch Installation Script
+# Manages installation, update, and removal of the wireless auto-switch utility
+#
+# Usage: ./install.sh [i|up|ui|--help]
+#   i  - Install system components
+#   up - Update existing installation
+#   ui - Uninstall system components
+#
+# Requirements: Administrator privileges for system directory access
+#
 
-PS3='[Please enter your choice]: '
-options=(
-    "install (i): install mode"       # 1
-    "uninstall (ui): uninstall mode" # 2
-    "update (up): update mode"       # 3
-    "quit: Exit from this menu"                        # 4
-    )
+set -euo pipefail  # Exit on error, undefined variables, and pipe failures
 
-function _sudo() {
-    SUDO=''
-    if [[ $(id -u) -ne 0 ]]; then
-        SUDO='sudo'
+# Constants
+readonly SCRIPT_NAME="install.sh"
+readonly NETBASICS_PATH="/Library/Scripts/NetBasics"
+readonly LAUNCHDAEMONS_PATH="/Library/LaunchDaemons"
+readonly DAEMON_NAME="com.computernetworkbasics.wifionoff"
+readonly DAEMON_PLIST="${DAEMON_NAME}.plist"
+readonly WIRELESS_SCRIPT="wireless.sh"
+
+# Global variables
+SUDO=""
+
+# Menu options for interactive mode
+readonly PS3='[Please enter your choice]: '
+readonly -a OPTIONS=(
+    "install (i): install mode"
+    "uninstall (ui): uninstall mode"
+    "update (up): update mode"
+    "quit: Exit from this menu"
+)
+
+#
+# Log message with script context
+# Arguments: $1 - log message
+#
+log_message() {
+    local message="$1"
+    echo "${SCRIPT_NAME}: ${message}"
+}
+
+#
+# Log error message and exit
+# Arguments: $1 - error message, $2 - exit code (optional, defaults to 1)
+#
+log_error_and_exit() {
+    local error_message="$1"
+    local exit_code="${2:-1}"
+    echo "ERROR: ${SCRIPT_NAME}: ${error_message}" >&2
+    exit "$exit_code"
+}
+
+#
+# Check if running as root, set SUDO variable accordingly
+#
+configure_sudo() {
+    if [[ $(id -u) -eq 0 ]]; then
+        SUDO=""
+        log_message "Running as root"
+    else
+        SUDO="sudo"
+        log_message "Running as non-root user, will use sudo for privileged operations"
     fi
 }
 
-function _mkdir() {
-    if [! -d $NETBASICS_PATH ]; then
-            $SUDO mkdir -p $NETBASICS_PATH;
+#
+# Create required system directories
+#
+create_directories() {
+    log_message "Creating system directories..."
+    
+    if [[ ! -d "$NETBASICS_PATH" ]]; then
+        if ! $SUDO mkdir -p "$NETBASICS_PATH"; then
+            log_error_and_exit "Failed to create directory $NETBASICS_PATH"
+        fi
+        log_message "Created directory: $NETBASICS_PATH"
+    else
+        log_message "Directory already exists: $NETBASICS_PATH"
     fi
-    if [! -d $LAUNCHDAEMONS_PATH ]; then
-            $SUDO mkdir -p $LAUNCHDAEMONS_PATH;
+    
+    if [[ ! -d "$LAUNCHDAEMONS_PATH" ]]; then
+        if ! $SUDO mkdir -p "$LAUNCHDAEMONS_PATH"; then
+            log_error_and_exit "Failed to create directory $LAUNCHDAEMONS_PATH"
+        fi
+        log_message "Created directory: $LAUNCHDAEMONS_PATH"
+    else
+        log_message "Directory already exists: $LAUNCHDAEMONS_PATH"
     fi
 }
 
-function _switch() {
-    _reply="$1"
+#
+# Validate that required source files exist
+#
+validate_source_files() {
+    local missing_files=()
+    
+    if [[ ! -f "$WIRELESS_SCRIPT" ]]; then
+        missing_files+=("$WIRELESS_SCRIPT")
+    fi
+    
+    if [[ ! -f "$DAEMON_PLIST" ]]; then
+        missing_files+=("$DAEMON_PLIST")
+    fi
+    
+    if [[ ${#missing_files[@]} -gt 0 ]]; then
+        log_error_and_exit "Missing required files: ${missing_files[*]}"
+    fi
+}
 
-    case $_reply in
-        ""|"i"|"install"|"1")
-            _sudo
-            _mkdir
-            $SUDO cp wireless.sh $NETBASICS_PATH;
-            $SUDO cp com.computernetworkbasics.wifionoff.plist $LAUNCHDAEMONS_PATH/com.computernetworkbasics.wifionoff.plist;
-            $SUDO chmod 755 $NETBASICS_PATH/wireless.sh;
-            $SUDO chown root:wheel $LAUNCHDAEMONS_PATH/com.computernetworkbasics.wifionoff.plist;
+#
+# Stop and unload the LaunchDaemon if it's running
+#
+stop_daemon() {
+    local daemon_path="${LAUNCHDAEMONS_PATH}/${DAEMON_PLIST}"
+    
+    if [[ -f "$daemon_path" ]]; then
+        log_message "Stopping LaunchDaemon..."
+        if $SUDO launchctl unload "$daemon_path" 2>/dev/null; then
+            log_message "LaunchDaemon stopped successfully"
+        else
+            log_message "LaunchDaemon was not running or failed to stop (this is normal)"
+        fi
+    fi
+}
+
+#
+# Load and start the LaunchDaemon
+#
+start_daemon() {
+    local daemon_path="${LAUNCHDAEMONS_PATH}/${DAEMON_PLIST}"
+    
+    if [[ -f "$daemon_path" ]]; then
+        log_message "Starting LaunchDaemon..."
+        if $SUDO launchctl load "$daemon_path"; then
+            log_message "LaunchDaemon started successfully"
+        else
+            log_error_and_exit "Failed to start LaunchDaemon"
+        fi
+    else
+        log_error_and_exit "LaunchDaemon plist file not found: $daemon_path"
+    fi
+}
+
+#
+# Install system components
+#
+install_components() {
+    log_message "Starting installation..."
+    
+    configure_sudo
+    validate_source_files
+    create_directories
+    stop_daemon
+    
+    # Copy wireless script
+    local wireless_dest="${NETBASICS_PATH}/${WIRELESS_SCRIPT}"
+    if ! $SUDO cp "$WIRELESS_SCRIPT" "$wireless_dest"; then
+        log_error_and_exit "Failed to copy $WIRELESS_SCRIPT to $wireless_dest"
+    fi
+    log_message "Copied: $WIRELESS_SCRIPT -> $wireless_dest"
+    
+    # Set script permissions
+    if ! $SUDO chmod 755 "$wireless_dest"; then
+        log_error_and_exit "Failed to set permissions on $wireless_dest"
+    fi
+    log_message "Set execute permissions on: $wireless_dest"
+    
+    # Copy LaunchDaemon plist
+    local daemon_dest="${LAUNCHDAEMONS_PATH}/${DAEMON_PLIST}"
+    if ! $SUDO cp "$DAEMON_PLIST" "$daemon_dest"; then
+        log_error_and_exit "Failed to copy $DAEMON_PLIST to $daemon_dest"
+    fi
+    log_message "Copied: $DAEMON_PLIST -> $daemon_dest"
+    
+    # Set plist ownership
+    if ! $SUDO chown root:wheel "$daemon_dest"; then
+        log_error_and_exit "Failed to set ownership on $daemon_dest"
+    fi
+    log_message "Set ownership (root:wheel) on: $daemon_dest"
+    
+    start_daemon
+    log_message "Installation completed successfully"
+}
+
+#
+# Uninstall system components
+#
+uninstall_components() {
+    log_message "Starting uninstallation..."
+    
+    configure_sudo
+    stop_daemon
+    
+    # Remove wireless script
+    local wireless_dest="${NETBASICS_PATH}/${WIRELESS_SCRIPT}"
+    if [[ -f "$wireless_dest" ]]; then
+        if ! $SUDO rm -f "$wireless_dest"; then
+            log_error_and_exit "Failed to remove $wireless_dest"
+        fi
+        log_message "Removed: $wireless_dest"
+    else
+        log_message "File not found (already removed): $wireless_dest"
+    fi
+    
+    # Remove LaunchDaemon plist
+    local daemon_dest="${LAUNCHDAEMONS_PATH}/${DAEMON_PLIST}"
+    if [[ -f "$daemon_dest" ]]; then
+        if ! $SUDO rm -f "$daemon_dest"; then
+            log_error_and_exit "Failed to remove $daemon_dest"
+        fi
+        log_message "Removed: $daemon_dest"
+    else
+        log_message "File not found (already removed): $daemon_dest"
+    fi
+    
+    # Remove directory if empty
+    if [[ -d "$NETBASICS_PATH" ]] && [[ -z "$(ls -A "$NETBASICS_PATH")" ]]; then
+        if ! $SUDO rmdir "$NETBASICS_PATH"; then
+            log_message "Warning: Failed to remove empty directory $NETBASICS_PATH"
+        else
+            log_message "Removed empty directory: $NETBASICS_PATH"
+        fi
+    fi
+    
+    log_message "Uninstallation completed successfully"
+}
+
+#
+# Update existing installation
+#
+update_components() {
+    log_message "Starting update..."
+    
+    configure_sudo
+    validate_source_files
+    stop_daemon
+    
+    # Update wireless script
+    local wireless_dest="${NETBASICS_PATH}/${WIRELESS_SCRIPT}"
+    if ! $SUDO cp "$WIRELESS_SCRIPT" "$wireless_dest"; then
+        log_error_and_exit "Failed to update $wireless_dest"
+    fi
+    log_message "Updated: $wireless_dest"
+    
+    # Set script permissions
+    if ! $SUDO chmod 755 "$wireless_dest"; then
+        log_error_and_exit "Failed to set permissions on $wireless_dest"
+    fi
+    
+    # Update LaunchDaemon plist
+    local daemon_dest="${LAUNCHDAEMONS_PATH}/${DAEMON_PLIST}"
+    if ! $SUDO cp "$DAEMON_PLIST" "$daemon_dest"; then
+        log_error_and_exit "Failed to update $daemon_dest"
+    fi
+    log_message "Updated: $daemon_dest"
+    
+    # Set plist ownership
+    if ! $SUDO chown root:wheel "$daemon_dest"; then
+        log_error_and_exit "Failed to set ownership on $daemon_dest"
+    fi
+    
+    start_daemon
+    log_message "Update completed successfully"
+}
+
+#
+# Display help information
+#
+show_help() {
+    cat << EOF
+macOS Wireless Auto-Switch Installation Script
+
+Usage: $0 [COMMAND]
+
+Commands:
+  i, install    Install the wireless auto-switch utility
+  up, update    Update the existing installation
+  ui, uninstall Remove the wireless auto-switch utility
+  --help        Show this help message
+
+Interactive Mode:
+  Run without arguments to enter interactive menu mode
+
+Examples:
+  $0 i          # Install the utility
+  $0 up         # Update existing installation
+  $0 ui         # Uninstall the utility
+
+Requirements:
+  - Administrator privileges (sudo access)
+  - macOS Ventura (13.x), Sonoma (14.x), or Sequoia (15.x)
+  - Source files: $WIRELESS_SCRIPT, $DAEMON_PLIST
+
+For more information, see the project documentation.
+EOF
+}
+
+#
+# Process command line arguments or interactive menu selection
+# Arguments: $1 - command/reply
+#
+process_command() {
+    local reply="$1"
+    
+    case "$reply" in
+        "i"|"install"|"1")
+            install_components
             ;;
-        ""|"ui"|"uninstall"|"2")
-            _sudo
-            $SUDO rm -Rf $NETBASICS_PATH/wireless.sh;
-            $SUDO rm -Rf $LAUNCHDAEMONS_PATH/com.computernetworkbasics.wifionoff.plist;
+        "ui"|"uninstall"|"2")
+            uninstall_components
             ;;
-        ""|"up"|"update"|"3")
-            _sudo
-            $SUDO cp wireless.sh $NETBASICS_PATH;
-            $SUDO cp com.computernetworkbasics.wifionoff.plist $LAUNCHDAEMONS_PATH/com.computernetworkbasics.wifionoff.plist;
-            $SUDO chmod 755 $NETBASICS_PATH/wireless.sh;
-            $SUDO chown root:wheel $LAUNCHDAEMONS_PATH/com.computernetworkbasics.wifionoff.plist;
-            exit
+        "up"|"update"|"3")
+            update_components
             ;;
-        ""|"quit"|"4")
-            echo "Goodbye!"
-            exit
+        "quit"|"4")
+            log_message "Goodbye!"
+            exit 0
             ;;
-        ""|"--help")
-            echo "Available commands:"
-            printf '%s\n' "${options[@]}"
+        "--help")
+            show_help
             ;;
-        *) echo "invalid option, use --help option for the commands list";;
+        "")
+            # Empty input in interactive mode - do nothing, continue loop
+            return 1
+            ;;
+        *)
+            echo "Invalid option: $reply"
+            echo "Use --help for available commands"
+            return 1
+            ;;
     esac
 }
 
-while true
-do
-    # run option directly if specified in argument
-    [ ! -z $1 ] && _switch $@
-    [ ! -z $1 ] && exit 0
-
-    echo "==== OPTIONS ===="
-    select opt in "${options[@]}"
-    do
-        _switch $REPLY
-        break
+#
+# Main execution function
+#
+main() {
+    # Process command line arguments if provided
+    if [[ $# -gt 0 ]]; then
+        process_command "$1"
+        exit $?
+    fi
+    
+    # Interactive menu mode
+    log_message "Starting interactive installation menu"
+    
+    while true; do
+        echo
+        echo "==== macOS Wireless Auto-Switch Installation Menu ===="
+        
+        select _ in "${OPTIONS[@]}"; do
+            if process_command "$REPLY"; then
+                break
+            fi
+        done
     done
-done
+}
+
+# Execute main function if script is run directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/wireless.sh
+++ b/wireless.sh
@@ -1,36 +1,187 @@
 #!/bin/bash
- 
-# Set toggle for found IP on an interface to FALSE to start
-IPFOUND=
-# Determine Current OS Version
-OSVERSION=$(uname -a | awk '{print $3}' | awk 'BEGIN {FS = "."} ; {print $1}')
-# Get list of possible wired ethernet interfaces
-INTERFACES=$(networksetup -listnetworkserviceorder | grep "Hardware Port" | grep "Ethernet\|LAN\|Thunderbolt\|AX88179A" | awk -F ": " '{print $3}'  | sed 's/)//g')
-# Get list of Wireless Interfaces
-WIFIINTERFACES=$(networksetup -listallhardwareports | tr '\n' ' ' | sed -e 's/Hardware Port:/\'$'\n/g' | grep Wi-Fi | awk '{print $3}')
- 
-# Look for an IP on all Ethernet interfaces.  If found set variable IPFOUND to true.
-for INTERFACE in $INTERFACES
-do
-  # Get Wired LAN IP (If there is one other then the loopback and the self assigned.)
-  IPCHECK=$(ifconfig "$INTERFACE" | grep -E 'inet [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | grep -E -v '127.0.0.1|169.254.' | awk '{print $2}')
-  if [ "$IPCHECK" ]; then
-    IPFOUND=true
-  fi
-done
- 
-# For Ventura (#22), Sonoma (#23), Sequoia (#24)
-if [ "$OSVERSION" == "22" ] || [ "$OSVERSION" == "23" ] || [ "$OSVERSION" == "24" ]; then
-  if [ $IPFOUND ]; then
-    /usr/sbin/networksetup -setairportpower "$WIFIINTERFACES" off || exit 1
-    echo "Turning OFF wireless on card $WIFIINTERFACES."
-    logger "wireless.sh: turning off wireless card ($WIFIINTERFACES) because an IP was found on a wired card."
-  else
-    /usr/sbin/networksetup -setairportpower "$WIFIINTERFACES" on || exit 1
-    echo "Turning ON wireless on card $WIFIINTERFACES."
-    logger "wireless.sh: turning on wireless card ($WIFIINTERFACES) because NO IP was found on a wired card."
-  fi
+
+#
+# macOS Wireless Auto-Switch Utility
+# Automatically toggles WiFi off when wired Ethernet connection is detected
+# and back on when disconnected. Supports Ventura, Sonoma, and Sequoia.
+#
+# Requirements: Root privileges, macOS 13+, Bash 4+
+# Usage: Executed automatically by LaunchDaemon on network configuration changes
+#
+
+set -euo pipefail  # Exit on error, undefined variables, and pipe failures
+
+# Constants
+readonly SCRIPT_NAME="wireless.sh"
+readonly SUPPORTED_ADAPTERS="Ethernet|LAN|Thunderbolt|AX88179A"
+readonly SUPPORTED_OS_VERSIONS="22|23|24"  # Ventura, Sonoma, Sequoia
+readonly LOOP_PREVENTION_DELAY=10
+
+# Global variables
+IPFOUND=""
+OSVERSION=""
+INTERFACES=""
+WIFIINTERFACES=""
+
+#
+# Log message to system log with script context
+# Arguments: $1 - log message
+#
+log_message() {
+    local message="$1"
+    logger "${SCRIPT_NAME}: ${message}"
+    echo "${SCRIPT_NAME}: ${message}"
+}
+
+#
+# Get the current macOS version number
+# Returns: OS version number (22, 23, 24, etc.)
+#
+get_os_version() {
+    uname -a | awk '{print $3}' | awk 'BEGIN {FS = "."} ; {print $1}'
+}
+
+#
+# Get list of wired ethernet interfaces by hardware port type
+# Returns: Space-separated list of interface names
+#
+get_wired_interfaces() {
+    /usr/sbin/networksetup -listnetworkserviceorder | \
+        grep "Hardware Port" | \
+        grep -E "${SUPPORTED_ADAPTERS}" | \
+        awk -F ": " '{print $3}' | \
+        sed 's/)//g'
+}
+
+#
+# Get list of WiFi interfaces
+# Returns: Space-separated list of WiFi interface names  
+#
+get_wifi_interfaces() {
+    /usr/sbin/networksetup -listallhardwareports | \
+        tr '\n' ' ' | \
+        sed -e 's/Hardware Port:/\n/g' | \
+        grep Wi-Fi | \
+        awk '{print $3}'
+}
+
+#
+# Check if a network interface has a valid IP address
+# Arguments: $1 - interface name
+# Returns: IP address if valid, empty string otherwise
+#
+get_interface_ip() {
+    local interface="$1"
+    
+    if [[ -z "$interface" ]]; then
+        return 1
+    fi
+    
+    # Get IP address, excluding loopback and self-assigned addresses
+    ifconfig "$interface" 2>/dev/null | \
+        grep -E 'inet [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | \
+        grep -E -v '127\.0\.0\.1|169\.254\.' | \
+        awk '{print $2}' | \
+        head -1
+}
+
+#
+# Check if any wired interface has a valid IP address
+# Sets global IPFOUND variable to "true" if found
+#
+detect_wired_connection() {
+    IPFOUND=""
+    
+    if [[ -z "$INTERFACES" ]]; then
+        log_message "No wired interfaces detected"
+        return 0
+    fi
+    
+    for interface in $INTERFACES; do
+        local ip_address
+        ip_address=$(get_interface_ip "$interface")
+        
+        if [[ -n "$ip_address" ]]; then
+            IPFOUND="true"
+            log_message "Active wired connection detected on interface $interface with IP $ip_address"
+            break
+        fi
+    done
+    
+    if [[ -z "$IPFOUND" ]]; then
+        log_message "No active wired connections detected"
+    fi
+}
+
+#
+# Toggle WiFi state based on wired connection status
+# Arguments: $1 - desired state ("on" or "off")
+#
+toggle_wifi() {
+    local desired_state="$1"
+    
+    if [[ -z "$WIFIINTERFACES" ]]; then
+        log_message "No WiFi interfaces found - skipping WiFi toggle"
+        return 0
+    fi
+    
+    if [[ "$desired_state" != "on" && "$desired_state" != "off" ]]; then
+        log_message "ERROR: Invalid WiFi state '$desired_state'. Must be 'on' or 'off'"
+        exit 1
+    fi
+    
+    # Execute WiFi toggle command
+    if ! /usr/sbin/networksetup -setairportpower "$WIFIINTERFACES" "$desired_state"; then
+        log_message "ERROR: Failed to set WiFi power to $desired_state on interface $WIFIINTERFACES"
+        exit 1
+    fi
+    
+    log_message "Successfully turned $desired_state WiFi on interface $WIFIINTERFACES"
+}
+
+#
+# Main execution logic
+#
+main() {
+    log_message "Starting network detection and WiFi management"
+    
+    # Get system information
+    OSVERSION=$(get_os_version)
+    log_message "Detected macOS version: $OSVERSION"
+    
+    # Validate OS compatibility
+    if [[ ! "$OSVERSION" =~ ^($SUPPORTED_OS_VERSIONS)$ ]]; then
+        log_message "WARNING: Unsupported macOS version $OSVERSION. Supported versions: Ventura (22), Sonoma (23), Sequoia (24)"
+        exit 1
+    fi
+    
+    # Get network interfaces
+    INTERFACES=$(get_wired_interfaces)
+    WIFIINTERFACES=$(get_wifi_interfaces)
+    
+    log_message "Detected wired interfaces: ${INTERFACES:-none}"
+    log_message "Detected WiFi interfaces: ${WIFIINTERFACES:-none}"
+    
+    # Detect wired connection status
+    detect_wired_connection
+    
+    # Manage WiFi state based on wired connection
+    if [[ -n "$IPFOUND" ]]; then
+        toggle_wifi "off"
+        log_message "WiFi disabled due to active wired connection"
+    else
+        toggle_wifi "on"
+        log_message "WiFi enabled due to no active wired connections"
+    fi
+    
+    # Prevent LaunchDaemon restart loops
+    log_message "Sleeping ${LOOP_PREVENTION_DELAY} seconds to prevent restart loops"
+    sleep "$LOOP_PREVENTION_DELAY"
+    
+    log_message "Network detection and WiFi management completed successfully"
+}
+
+# Execute main function if script is run directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
 fi
- 
-# This sleep prevents LaunchDaemons from thinking the script failed and running it again.
-sleep 10


### PR DESCRIPTION
This pull request introduces significant improvements to the macOS Wireless Auto-Switch utility, focusing on enhanced reliability, maintainability, and user experience. The most important changes include a complete refactor of the `install.sh` script for robust installation and management, expanded and clarified documentation in `README.md`, improved system integration via the LaunchDaemon plist, and workflow adjustments for validation. These updates streamline installation, improve error handling, and provide clearer guidance for users.

**Installation and Management Refactor:**

* Completely rewrote `install.sh` for reliability and maintainability, adding robust error handling, clear logging, privilege detection, directory management, and modular functions for install, update, and uninstall operations. The script now supports both command-line and interactive modes, provides a help menu, and ensures proper permissions and ownership for installed files.

**Documentation and User Guidance:**

* Major update to `README.md` with improved project description, clearer feature list, streamlined installation and usage instructions, expanded troubleshooting section, and detailed explanations of system components and requirements. Badges and resource links were added for clarity and discoverability. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R56) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R131) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L143-R172)

**System Integration and LaunchDaemon Improvements:**

* Enhanced `com.computernetworkbasics.wifionoff.plist` by specifying root execution, logging paths, throttling interval, and explicit daemon behaviors (`RunAtLoad`, `KeepAlive`). These changes improve reliability, logging, and prevent excessive script execution during rapid network changes.

**Workflow and Validation Updates:**

* Updated `.github/workflows/validate.yml` to use `libxml2-utils` for XML validation and corrected the syntax for macOS version checks, ensuring compatibility and accurate validation in CI. [[1]](diffhunk://#diff-a5c0f08bc43f53a0451cad4a4a2e435ce55ad34183350dfae5e4b2c7dca6360bL26-R26) [[2]](diffhunk://#diff-a5c0f08bc43f53a0451cad4a4a2e435ce55ad34183350dfae5e4b2c7dca6360bL188-R188)