### PR TITLE
fix: Update release name format in GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ steps.generate_version.outputs.new_version }}
-        release_name: macOS Wireless Auto-Switch ${{ steps.generate_version.outputs.new_version }}
+        release_name: ${{ steps.generate_version.outputs.new_version }}
         body_path: release_notes.md
         draft: false
         prerelease: false


### PR DESCRIPTION
This pull request makes a minor adjustment to the release workflow by simplifying the release name.

* The `release_name` in `.github/workflows/release.yml` is now set to just the version number, removing the "macOS Wireless Auto-Switch" prefix for a cleaner release title.