### PR TITLE
fix: resolve three bugs (#26, #27, #28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `wireless.sh`: `set -e` + empty grep silently killed the script before WiFi could be re-enabled; bare assignments now use `|| INTERFACES=""` / `|| WIFIINTERFACES=""` guards (fixes #27)
+- `wireless.sh`: `toggle_wifi` passed multi-line `$WIFIINTERFACES` as one argument, failing on Macs with multiple WiFi adapters; now iterates per interface (fixes #28)
+- `install.sh`: missing `chmod 644` on installed plist caused `launchctl` to silently refuse loading on systems with a restrictive umask; added to both `install_components` and `update_components` (fixes #26)
+
 ## [1.0.6] – 2025
 
 ### Added

--- a/install.sh
+++ b/install.sh
@@ -176,11 +176,14 @@ install_components() {
     fi
     log_message "Copied: $DAEMON_PLIST -> $daemon_dest"
     
-    # Set plist ownership
+    # Set plist ownership and permissions (644 required for launchctl to load)
     if ! $SUDO chown root:wheel "$daemon_dest"; then
         log_error_and_exit "Failed to set ownership on $daemon_dest"
     fi
-    log_message "Set ownership (root:wheel) on: $daemon_dest"
+    if ! $SUDO chmod 644 "$daemon_dest"; then
+        log_error_and_exit "Failed to set permissions on $daemon_dest"
+    fi
+    log_message "Set ownership (root:wheel) and permissions (644) on: $daemon_dest"
     
     start_daemon
     log_message "Installation completed successfully"
@@ -258,9 +261,12 @@ update_components() {
     fi
     log_message "Updated: $daemon_dest"
     
-    # Set plist ownership
+    # Set plist ownership and permissions (644 required for launchctl to load)
     if ! $SUDO chown root:wheel "$daemon_dest"; then
         log_error_and_exit "Failed to set ownership on $daemon_dest"
+    fi
+    if ! $SUDO chmod 644 "$daemon_dest"; then
+        log_error_and_exit "Failed to set permissions on $daemon_dest"
     fi
     
     start_daemon

--- a/wireless.sh
+++ b/wireless.sh
@@ -143,13 +143,16 @@ toggle_wifi() {
         exit 1
     fi
     
-    # Execute WiFi toggle command
-    if ! /usr/sbin/networksetup -setairportpower "$WIFIINTERFACES" "$desired_state"; then
-        log_message "ERROR: Failed to set WiFi power to $desired_state on interface $WIFIINTERFACES"
-        exit 1
-    fi
-    
-    log_message "Successfully turned $desired_state WiFi on interface $WIFIINTERFACES"
+    # Iterate over each WiFi interface (handles multi-adapter Macs)
+    local iface
+    while IFS= read -r iface; do
+        [[ -z "$iface" ]] && continue
+        if ! /usr/sbin/networksetup -setairportpower "$iface" "$desired_state"; then
+            log_message "ERROR: Failed to set WiFi power to $desired_state on interface $iface"
+            exit 1
+        fi
+        log_message "Successfully turned $desired_state WiFi on interface $iface"
+    done <<< "$WIFIINTERFACES"
 }
 
 #
@@ -168,9 +171,9 @@ main() {
         exit 1
     fi
     
-    # Get network interfaces
-    INTERFACES=$(get_wired_interfaces)
-    WIFIINTERFACES=$(get_wifi_interfaces)
+    # Get network interfaces (|| "" guards against set -e killing the script when grep finds no matches)
+    INTERFACES=$(get_wired_interfaces) || INTERFACES=""
+    WIFIINTERFACES=$(get_wifi_interfaces) || WIFIINTERFACES=""
     
     log_message "Detected wired interfaces: ${INTERFACES:-none}"
     log_message "Detected WiFi interfaces: ${WIFIINTERFACES:-none}"


### PR DESCRIPTION
## Summary

Fixes three bugs reported in issues #26, #27, #28.

### #27 — `set -e` + empty grep silently kills script, WiFi never re-enabled
**File:** `wireless.sh`  
Bare assignments like `INTERFACES=$(get_wired_interfaces)` are killed by `set -e` when the inner grep returns exit 1 (no matches). Added `|| INTERFACES=""` / `|| WIFIINTERFACES=""` guards.

### #28 — `toggle_wifi` fails on machines with multiple WiFi adapters
**File:** `wireless.sh`  
`$WIFIINTERFACES` (newline-separated) was passed as a single quoted argument to `networksetup`. Now iterates with `while IFS= read -r iface` over each interface.

### #26 — missing `chmod 644` on plist, launchctl silently refuses to load
**File:** `install.sh`  
Added `chmod 644` after `chown root:wheel` in both `install_components` and `update_components`.

Closes #26, #27, #28