### PR TITLE
fix: resolve three bugs (#30, #31, #32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `wireless.sh`: `toggle_wifi` mid-loop `exit 1` left multi-adapter Macs in a split WiFi state; loop now completes all interfaces before exiting non-zero (fixes #32)
+- `com.computernetworkbasics.wifionoff.plist`: `RunAtLoad: false` meant booting with Ethernet already connected never triggered the daemon; changed to `true` (fixes #31)
+- `install.sh`: bare filenames resolved against `$PWD` caused "Missing required files" when not run from the repo directory; `main()` now `cd`s to script directory first (fixes #30)
+
+### Fixed
 - `wireless.sh`: `set -e` + empty grep silently killed the script before WiFi could be re-enabled; bare assignments now use `|| INTERFACES=""` / `|| WIFIINTERFACES=""` guards (fixes #27)
 - `wireless.sh`: `toggle_wifi` passed multi-line `$WIFIINTERFACES` as one argument, failing on Macs with multiple WiFi adapters; now iterates per interface (fixes #28)
 - `install.sh`: missing `chmod 644` on installed plist caused `launchctl` to silently refuse loading on systems with a restrictive umask; added to both `install_components` and `update_components` (fixes #26)

--- a/com.computernetworkbasics.wifionoff.plist
+++ b/com.computernetworkbasics.wifionoff.plist
@@ -23,7 +23,7 @@
     <string>/var/log/wireless-autoswitch.log</string>
     
     <key>RunAtLoad</key>
-    <false/>
+    <true/>
     <key>KeepAlive</key>
     <false/>
     

--- a/install.sh
+++ b/install.sh
@@ -345,6 +345,10 @@ process_command() {
 # Main execution function
 #
 main() {
+    # Resolve paths relative to the script's own directory so install.sh works
+    # when invoked from any working directory (e.g. sudo /path/to/install.sh i)
+    cd "$(dirname "${BASH_SOURCE[0]}")"
+
     # Process command line arguments if provided
     if [[ $# -gt 0 ]]; then
         process_command "$1"

--- a/wireless.sh
+++ b/wireless.sh
@@ -143,16 +143,18 @@ toggle_wifi() {
         exit 1
     fi
     
-    # Iterate over each WiFi interface (handles multi-adapter Macs)
-    local iface
+    # Iterate all adapters; accumulate failures so no interface is left in a split state
+    local iface failed=0
     while IFS= read -r iface; do
         [[ -z "$iface" ]] && continue
         if ! /usr/sbin/networksetup -setairportpower "$iface" "$desired_state"; then
             log_message "ERROR: Failed to set WiFi power to $desired_state on interface $iface"
-            exit 1
+            failed=1
+        else
+            log_message "Successfully turned $desired_state WiFi on interface $iface"
         fi
-        log_message "Successfully turned $desired_state WiFi on interface $iface"
     done <<< "$WIFIINTERFACES"
+    [[ $failed -eq 0 ]] || exit 1
 }
 
 #


### PR DESCRIPTION
## Summary

Fixes three bugs reported in issues #30, #31, #32.

### #32 — `exit 1` inside `toggle_wifi` loop leaves multi-adapter Macs in split WiFi state
**File:** `wireless.sh`
Mid-loop `exit 1` on one adapter failure abandoned remaining interfaces. Loop now iterates all interfaces, accumulates failures in `failed`, and exits non-zero only after completing the full pass.

### #31 — `RunAtLoad: false` means WiFi stays on after booting with Ethernet already connected
**File:** `com.computernetworkbasics.wifionoff.plist`
`WatchPaths` only fires on *changes* — a machine booted with Ethernet already plugged in never triggers the daemon. Changed `RunAtLoad` to `true` so the script runs once at daemon load time.

### #30 — `install.sh` fails when not run from the repository directory
**File:** `install.sh`
Bare filenames (`wireless.sh`, `*.plist`) were resolved against `$PWD`. Added `cd "$(dirname "${BASH_SOURCE[0]}")"` at the start of `main()` to anchor resolution to the script's own directory.

Closes #30, #31, #32