### PR TITLE
ci: simplify and modernize workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,210 +2,54 @@ name: Create Release
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
       - 'wireless.sh'
       - 'install.sh'
       - 'com.computernetworkbasics.wifionoff.plist'
-    types: [ closed ]
+    types: [closed]
 
 jobs:
   release:
-    # Only run on merged PRs
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    
+
     permissions:
       contents: write
-      pull-requests: read
-    
+
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v7
-      with:
-        fetch-depth: 0
-    
-    - name: Get latest tag
-      id: get_latest_tag
-      run: |
-        # Get the latest tag, or use v1.0.0 if no tags exist
-        LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v1.0.0")
-        echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
-        echo "Latest tag: $LATEST_TAG"
-    
-    - name: Generate new version
-      id: generate_version
-      run: |
-        LATEST_TAG="${{ steps.get_latest_tag.outputs.latest_tag }}"
-        
-        # Remove 'v' prefix if present
-        VERSION=${LATEST_TAG#v}
-        
-        # Split version into parts
-        IFS='.' read -r -a VERSION_PARTS <<< "$VERSION"
-        MAJOR=${VERSION_PARTS[0]:-1}
-        MINOR=${VERSION_PARTS[1]:-0}
-        PATCH=${VERSION_PARTS[2]:-0}
-        
-        # Increment patch version
-        PATCH=$((PATCH + 1))
-        
-        NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
-        echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-        echo "New version: $NEW_VERSION"
-    
-    - name: Check for changes in core files
-      id: check_changes
-      run: |
-        # Check if any of the core files have changed since the last tag
-        LATEST_TAG="${{ steps.get_latest_tag.outputs.latest_tag }}"
-        
-        if git rev-parse "$LATEST_TAG" >/dev/null 2>&1; then
-          CHANGED_FILES=$(git diff --name-only "$LATEST_TAG"..HEAD -- wireless.sh install.sh com.computernetworkbasics.wifionoff.plist)
-        else
-          # If no previous tag exists, consider files as changed
-          CHANGED_FILES="wireless.sh install.sh com.computernetworkbasics.wifionoff.plist"
-        fi
-        
-        if [ -n "$CHANGED_FILES" ]; then
-          echo "changes_detected=true" >> $GITHUB_OUTPUT
-          echo "Changed files:"
-          echo "$CHANGED_FILES"
-        else
-          echo "changes_detected=false" >> $GITHUB_OUTPUT
-          echo "No changes detected in core files since last release"
-        fi
-    
-    - name: Generate release notes
-      id: release_notes
-      if: steps.check_changes.outputs.changes_detected == 'true'
-      run: |
-        LATEST_TAG="${{ steps.get_latest_tag.outputs.latest_tag }}"
-        NEW_VERSION="${{ steps.generate_version.outputs.new_version }}"
-        
-        # Create release notes
-        echo "## Changes in $NEW_VERSION" > release_notes.md
-        echo "" >> release_notes.md
-        
-        if git rev-parse "$LATEST_TAG" >/dev/null 2>&1; then
-          echo "### Updated Files" >> release_notes.md
-          CHANGED_FILES=$(git diff --name-only "$LATEST_TAG"..HEAD -- wireless.sh install.sh com.computernetworkbasics.wifionoff.plist)
-          for file in $CHANGED_FILES; do
-            echo "- \`$file\`" >> release_notes.md
-          done
-          echo "" >> release_notes.md
-          
-          echo "### Commit History" >> release_notes.md
-          git log "$LATEST_TAG"..HEAD --oneline --format="- %s (%h)" >> release_notes.md
-        else
-          echo "### Initial Release" >> release_notes.md
-          echo "This is the initial release of macOS Wireless Auto-Switch utility." >> release_notes.md
-          echo "" >> release_notes.md
-          echo "### Core Components" >> release_notes.md
-          echo "- \`wireless.sh\` - Main logic script for WiFi auto-switching" >> release_notes.md
-          echo "- \`install.sh\` - Installation and management script" >> release_notes.md
-          echo "- \`com.computernetworkbasics.wifionoff.plist\` - LaunchDaemon configuration" >> release_notes.md
-        fi
-        
-        echo "" >> release_notes.md
-        echo "### Installation" >> release_notes.md
-        echo "1. Download the release archive" >> release_notes.md
-        echo "2. Extract the files" >> release_notes.md
-        echo "3. Run \`./install.sh i\` to install" >> release_notes.md
-        echo "" >> release_notes.md
-        echo "### Compatibility" >> release_notes.md
-        echo "- macOS Sonoma (14.x)" >> release_notes.md
-        echo "- macOS Sequoia (15.x)" >> release_notes.md
-        echo "- macOS Tahoe (16.x)" >> release_notes.md
-    
-    - name: Create release archive
-      if: steps.check_changes.outputs.changes_detected == 'true'
-      run: |
-        NEW_VERSION="${{ steps.generate_version.outputs.new_version }}"
-        ARCHIVE_NAME="macos-wireless-autoswitch-$NEW_VERSION"
-        
-        # Create archive directory
-        mkdir -p "$ARCHIVE_NAME"
-        
-        # Copy core files
-        cp wireless.sh "$ARCHIVE_NAME/"
-        cp install.sh "$ARCHIVE_NAME/"
-        cp com.computernetworkbasics.wifionoff.plist "$ARCHIVE_NAME/"
-        cp README.md "$ARCHIVE_NAME/"
-        cp LICENSE "$ARCHIVE_NAME/"
-        
-        # Create installation instructions
-        {
-          echo "macOS Wireless Auto-Switch Installation Instructions"
-          echo "=================================================="
-          echo ""
-          echo "1. Open Terminal and navigate to this directory"
-          echo "2. Make the install script executable:"
-          echo "   chmod +x install.sh"
-          echo "3. Run the installer:"
-          echo "   ./install.sh i"
-          echo "4. The utility will now automatically toggle WiFi when wired connections are detected"
-          echo ""
-          echo "Uninstallation:"
-          echo "   ./install.sh ui"
-          echo ""
-          echo "Update:"
-          echo "   ./install.sh up"
-          echo ""
-          echo "For more information, see README.md"
-        } > "$ARCHIVE_NAME/INSTALL.txt"
-        
-        # Create tar.gz archive
-        tar -czf "$ARCHIVE_NAME.tar.gz" "$ARCHIVE_NAME"
-        
-        # Create zip archive for broader compatibility
-        zip -r "$ARCHIVE_NAME.zip" "$ARCHIVE_NAME"
-        
-        echo "archive_name=$ARCHIVE_NAME" >> $GITHUB_ENV
-    
-    - name: Create Release
-      if: steps.check_changes.outputs.changes_detected == 'true'
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ steps.generate_version.outputs.new_version }}
-        release_name: ${{ steps.generate_version.outputs.new_version }}
-        body_path: release_notes.md
-        draft: false
-        prerelease: false
-      id: create_release
-    
-    - name: Upload tar.gz archive
-      if: steps.check_changes.outputs.changes_detected == 'true'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./${{ env.archive_name }}.tar.gz
-        asset_name: ${{ env.archive_name }}.tar.gz
-        asset_content_type: application/gzip
-    
-    - name: Upload zip archive
-      if: steps.check_changes.outputs.changes_detected == 'true'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./${{ env.archive_name }}.zip
-        asset_name: ${{ env.archive_name }}.zip
-        asset_content_type: application/zip
-    
-    - name: Summary
-      if: steps.check_changes.outputs.changes_detected == 'true'
-      run: |
-        echo "✅ Release ${{ steps.generate_version.outputs.new_version }} created successfully!"
-        echo "📦 Archives: ${{ env.archive_name }}.tar.gz and ${{ env.archive_name }}.zip"
-        echo "🔗 Release URL: ${{ steps.create_release.outputs.html_url }}"
-    
-    - name: No changes detected
-      if: steps.check_changes.outputs.changes_detected == 'false'
-      run: |
-        echo "ℹ️ No changes detected in core files since last release. Skipping release creation."
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Get latest tag
+        id: tag
+        run: |
+          LATEST=$(git describe --tags --abbrev=0 2>/dev/null || echo "v1.0.0")
+          echo "latest=$LATEST" >> $GITHUB_OUTPUT
+
+      - name: Bump patch version
+        id: version
+        run: |
+          V="${{ steps.tag.outputs.latest }}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "${V#v}"
+          echo "new=v${MAJOR}.${MINOR}.$((PATCH + 1))" >> $GITHUB_OUTPUT
+
+      - name: Build archives
+        run: |
+          NAME="macos-wireless-autoswitch-${{ steps.version.outputs.new }}"
+          mkdir "$NAME"
+          cp wireless.sh install.sh com.computernetworkbasics.wifionoff.plist README.md LICENSE "$NAME/"
+          tar -czf "$NAME.tar.gz" "$NAME"
+          zip -r "$NAME.zip" "$NAME"
+          echo "ARCHIVE=$NAME" >> $GITHUB_ENV
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.new }}" \
+            --title "${{ steps.version.outputs.new }}" \
+            --generate-notes \
+            "${{ env.ARCHIVE }}.tar.gz" \
+            "${{ env.ARCHIVE }}.zip"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,199 +12,39 @@ on:
       - 'install.sh'
       - 'com.computernetworkbasics.wifionoff.plist'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: read
+
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v7
-    
-    - name: Install validation tools
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y shellcheck libxml2-utils
-    
-    - name: Validate shell scripts
-      run: |
-        echo "🔍 Validating shell scripts..."
-        
-        # Check if wireless.sh exists and is executable
-        if [ -f "wireless.sh" ]; then
-          echo "✅ wireless.sh exists"
-          
-          # Check shebang
-          if head -n1 wireless.sh | grep -q "#!/bin/bash"; then
-            echo "✅ wireless.sh has correct shebang"
-          else
-            echo "❌ wireless.sh missing or incorrect shebang"
-            exit 1
-          fi
-          
-          # Run shellcheck
-          echo "🔍 Running shellcheck on wireless.sh..."
-          shellcheck wireless.sh || echo "⚠️ Shellcheck warnings found in wireless.sh"
-          
-          # Check for required functions/commands
-          if grep -q "networksetup" wireless.sh; then
-            echo "✅ wireless.sh contains networksetup commands"
-          else
-            echo "❌ wireless.sh missing networksetup commands"
-            exit 1
-          fi
-          
-          if grep -q "setairportpower" wireless.sh; then
-            echo "✅ wireless.sh contains WiFi control logic"
-          else
-            echo "❌ wireless.sh missing WiFi control logic"
-            exit 1
-          fi
-        else
-          echo "❌ wireless.sh not found"
-          exit 1
-        fi
-        
-        # Check install.sh
-        if [ -f "install.sh" ]; then
-          echo "✅ install.sh exists"
-          
-          # Check shebang
-          if head -n1 install.sh | grep -q "#!/bin/bash"; then
-            echo "✅ install.sh has correct shebang"
-          else
-            echo "❌ install.sh missing or incorrect shebang"
-            exit 1
-          fi
-          
-          # Run shellcheck
-          echo "🔍 Running shellcheck on install.sh..."
-          shellcheck install.sh || echo "⚠️ Shellcheck warnings found in install.sh"
-          
-          # Check for required paths
-          if grep -q "/Library/Scripts/NetBasics" install.sh; then
-            echo "✅ install.sh contains correct installation path"
-          else
-            echo "❌ install.sh missing installation path"
-            exit 1
-          fi
-          
-          if grep -q "/Library/LaunchDaemons" install.sh; then
-            echo "✅ install.sh contains LaunchDaemon path"
-          else
-            echo "❌ install.sh missing LaunchDaemon path"
-            exit 1
-          fi
-        else
-          echo "❌ install.sh not found"
-          exit 1
-        fi
-    
-    - name: Validate plist file
-      run: |
-        echo "🔍 Validating plist file..."
-        
-        if [ -f "com.computernetworkbasics.wifionoff.plist" ]; then
-          echo "✅ Plist file exists"
-          
-          # Validate XML structure
-          if xmllint --noout com.computernetworkbasics.wifionoff.plist; then
-            echo "✅ Plist file has valid XML structure"
-          else
-            echo "❌ Plist file has invalid XML structure"
-            exit 1
-          fi
-          
-          # Check for required keys
-          if grep -q "<key>Label</key>" com.computernetworkbasics.wifionoff.plist; then
-            echo "✅ Plist contains Label key"
-          else
-            echo "❌ Plist missing Label key"
-            exit 1
-          fi
-          
-          if grep -q "<key>ProgramArguments</key>" com.computernetworkbasics.wifionoff.plist; then
-            echo "✅ Plist contains ProgramArguments key"
-          else
-            echo "❌ Plist missing ProgramArguments key"
-            exit 1
-          fi
-          
-          if grep -q "<key>WatchPaths</key>" com.computernetworkbasics.wifionoff.plist; then
-            echo "✅ Plist contains WatchPaths key"
-          else
-            echo "❌ Plist missing WatchPaths key"
-            exit 1
-          fi
-          
-          if grep -q "/Library/Scripts/NetBasics/wireless.sh" com.computernetworkbasics.wifionoff.plist; then
-            echo "✅ Plist references correct script path"
-          else
-            echo "❌ Plist missing or incorrect script path"
-            exit 1
-          fi
-          
-          if grep -q "/Library/Preferences/SystemConfiguration" com.computernetworkbasics.wifionoff.plist; then
-            echo "✅ Plist watches correct system path"
-          else
-            echo "❌ Plist missing or incorrect watch path"
-            exit 1
-          fi
-        else
-          echo "❌ Plist file not found"
-          exit 1
-        fi
-    
-    - name: Check file permissions
-      run: |
-        echo "🔍 Checking recommended file permissions..."
-        
-        # Check if shell scripts are executable
-        if [ -x "wireless.sh" ]; then
-          echo "✅ wireless.sh is executable"
-        else
-          echo "⚠️ wireless.sh is not executable (will be set during installation)"
-        fi
-        
-        if [ -x "install.sh" ]; then
-          echo "✅ install.sh is executable"
-        else
-          echo "⚠️ install.sh is not executable"
-          echo "💡 Consider running: chmod +x install.sh"
-        fi
-    
-    - name: Validate macOS compatibility
-      run: |
-        echo "🔍 Checking macOS compatibility markers..."
-        
-        # Check for OS version detection
-        if grep -q "uname -a" wireless.sh; then
-          echo "✅ OS version detection present"
-        else
-          echo "❌ OS version detection missing"
-          exit 1
-        fi
-        
-        # Check for supported OS versions
-        if grep -q "23|24|25" wireless.sh; then
-          echo "✅ Supported macOS versions defined (Sonoma, Sequoia, Tahoe)"
-        else
-          echo "❌ macOS version support not properly defined"
-          exit 1
-        fi
-        
-        # Check for networksetup usage
-        if grep -q "networksetup.*listnetworkserviceorder" wireless.sh; then
-          echo "✅ Network interface detection present"
-        else
-          echo "❌ Network interface detection missing"
-          exit 1
-        fi
-    
-    - name: Summary
-      run: |
-        echo ""
-        echo "🎉 Validation completed successfully!"
-        echo "✅ All core files are properly formatted and contain required components"
-        echo "✅ Shell scripts pass basic syntax validation"
-        echo "✅ Plist file has valid XML structure and required keys"
-        echo "✅ macOS compatibility checks passed"
+      - uses: actions/checkout@v4
+
+      - name: Install xmllint
+        run: sudo apt-get install -y --no-install-recommends libxml2-utils
+
+      - name: Lint shell scripts
+        run: shellcheck wireless.sh install.sh
+
+      - name: Validate plist XML
+        run: xmllint --noout com.computernetworkbasics.wifionoff.plist
+
+      - name: Check required content
+        run: |
+          grep -q "#!/bin/bash" wireless.sh install.sh
+          grep -qE "networksetup.*setairportpower" wireless.sh
+          grep -qE "networksetup.*listnetworkserviceorder" wireless.sh
+          grep -qE "uname -a" wireless.sh
+          grep -qE "23\|24\|25" wireless.sh
+          grep -q "/Library/Scripts/NetBasics" install.sh
+          grep -q "/Library/LaunchDaemons" install.sh
+          grep -q "<key>Label</key>" com.computernetworkbasics.wifionoff.plist
+          grep -q "<key>ProgramArguments</key>" com.computernetworkbasics.wifionoff.plist
+          grep -q "<key>WatchPaths</key>" com.computernetworkbasics.wifionoff.plist
+          grep -q "/Library/Scripts/NetBasics/wireless.sh" com.computernetworkbasics.wifionoff.plist
+          grep -q "/Library/Preferences/SystemConfiguration" com.computernetworkbasics.wifionoff.plist


### PR DESCRIPTION
- `validate.yml`: replace verbose echo/if blocks with direct `shellcheck`, `xmllint`, and `grep`; add concurrency cancel-in-progress; drop useless permission-check step (210 → 49 lines)
- `release.yml`: replace deprecated `create-release@v1` + `upload-release-asset@v1` with `gh release create --generate-notes`; remove redundant `check_changes` step; drop unused `pull-requests` permission (211 → 54 lines)