### PR TITLE
refactor: simplify both scripts (#36, #37, #38, #39, #40, #41)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,7 +39,7 @@ jobs:
           grep -q "#!/bin/bash" wireless.sh install.sh
           grep -qE "networksetup.*setairportpower" wireless.sh
           grep -qE "networksetup.*listnetworkserviceorder" wireless.sh
-          grep -qE "uname -a" wireless.sh
+          grep -qE "uname -r" wireless.sh
           grep -qE "23\|24\|25" wireless.sh
           grep -q "/Library/Scripts/NetBasics" install.sh
           grep -q "/Library/LaunchDaemons" install.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `wireless.sh`: `SCRIPT_NAME` now uses `$(basename "$0")` instead of a hardcoded string (fixes #39)
+- `wireless.sh`: `get_os_version` simplified from double-awk to `uname -r | cut -d. -f1` (fixes #36)
+- `wireless.sh`: removed unreachable empty-interface guard in `get_interface_ip` (fixes #37)
+- `wireless.sh`: `detect_wired_connection` now returns exit code (0=found, 1=not found) instead of setting `IPFOUND` global; removed `IPFOUND`/`OSVERSION` module-level globals (fixes #38)
+- `install.sh`: `SCRIPT_NAME` now uses `$(basename "$0")` instead of a hardcoded string (fixes #39)
+- `install.sh`: `validate_source_files` simplified from 13-line array accumulator to 2-line guards (fixes #41)
+- `install.sh`: extracted `_deploy_files` helper to eliminate ~20-line duplication between `install_components` and `update_components` (fixes #40)
+
 ### Added
 - `.github/skills/sync-docs`: new Copilot skill that audits `AGENTS.md` and `.github/copilot-instructions.md` against the live source, patches stale values, updates `CHANGELOG.md [Unreleased]`, then commits and pushes
 

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,8 @@
 set -euo pipefail  # Exit on error, undefined variables, and pipe failures
 
 # Constants
-readonly SCRIPT_NAME="$(basename "$0")"
+SCRIPT_NAME="$(basename "$0")"
+readonly SCRIPT_NAME
 readonly NETBASICS_PATH="/Library/Scripts/NetBasics"
 readonly LAUNCHDAEMONS_PATH="/Library/LaunchDaemons"
 readonly DAEMON_NAME="com.computernetworkbasics.wifionoff"

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@
 set -euo pipefail  # Exit on error, undefined variables, and pipe failures
 
 # Constants
-readonly SCRIPT_NAME="install.sh"
+readonly SCRIPT_NAME="$(basename "$0")"
 readonly NETBASICS_PATH="/Library/Scripts/NetBasics"
 readonly LAUNCHDAEMONS_PATH="/Library/LaunchDaemons"
 readonly DAEMON_NAME="com.computernetworkbasics.wifionoff"
@@ -96,19 +96,8 @@ create_directories() {
 # Validate that required source files exist
 #
 validate_source_files() {
-    local missing_files=()
-    
-    if [[ ! -f "$WIRELESS_SCRIPT" ]]; then
-        missing_files+=("$WIRELESS_SCRIPT")
-    fi
-    
-    if [[ ! -f "$DAEMON_PLIST" ]]; then
-        missing_files+=("$DAEMON_PLIST")
-    fi
-    
-    if [[ ${#missing_files[@]} -gt 0 ]]; then
-        log_error_and_exit "Missing required files: ${missing_files[*]}"
-    fi
+    [[ -f "$WIRELESS_SCRIPT" ]] || log_error_and_exit "Missing required file: $WIRELESS_SCRIPT"
+    [[ -f "$DAEMON_PLIST" ]]    || log_error_and_exit "Missing required file: $DAEMON_PLIST"
 }
 
 #
@@ -146,46 +135,38 @@ start_daemon() {
 }
 
 #
+# Copy files, set permissions, and start daemon (shared by install and update)
+#
+_deploy_files() {
+    local wireless_dest="${NETBASICS_PATH}/${WIRELESS_SCRIPT}"
+    $SUDO cp "$WIRELESS_SCRIPT" "$wireless_dest" \
+        || log_error_and_exit "Failed to copy $WIRELESS_SCRIPT to $wireless_dest"
+    $SUDO chmod 755 "$wireless_dest" \
+        || log_error_and_exit "Failed to set permissions on $wireless_dest"
+    log_message "Deployed: $wireless_dest"
+
+    local daemon_dest="${LAUNCHDAEMONS_PATH}/${DAEMON_PLIST}"
+    $SUDO cp "$DAEMON_PLIST" "$daemon_dest" \
+        || log_error_and_exit "Failed to copy $DAEMON_PLIST to $daemon_dest"
+    $SUDO chown root:wheel "$daemon_dest" \
+        || log_error_and_exit "Failed to set ownership on $daemon_dest"
+    $SUDO chmod 644 "$daemon_dest" \
+        || log_error_and_exit "Failed to set permissions on $daemon_dest"
+    log_message "Deployed: $daemon_dest (root:wheel, 644)"
+
+    start_daemon
+}
+
+#
 # Install system components
 #
 install_components() {
     log_message "Starting installation..."
-    
     configure_sudo
     validate_source_files
     create_directories
     stop_daemon
-    
-    # Copy wireless script
-    local wireless_dest="${NETBASICS_PATH}/${WIRELESS_SCRIPT}"
-    if ! $SUDO cp "$WIRELESS_SCRIPT" "$wireless_dest"; then
-        log_error_and_exit "Failed to copy $WIRELESS_SCRIPT to $wireless_dest"
-    fi
-    log_message "Copied: $WIRELESS_SCRIPT -> $wireless_dest"
-    
-    # Set script permissions
-    if ! $SUDO chmod 755 "$wireless_dest"; then
-        log_error_and_exit "Failed to set permissions on $wireless_dest"
-    fi
-    log_message "Set execute permissions on: $wireless_dest"
-    
-    # Copy LaunchDaemon plist
-    local daemon_dest="${LAUNCHDAEMONS_PATH}/${DAEMON_PLIST}"
-    if ! $SUDO cp "$DAEMON_PLIST" "$daemon_dest"; then
-        log_error_and_exit "Failed to copy $DAEMON_PLIST to $daemon_dest"
-    fi
-    log_message "Copied: $DAEMON_PLIST -> $daemon_dest"
-    
-    # Set plist ownership and permissions (644 required for launchctl to load)
-    if ! $SUDO chown root:wheel "$daemon_dest"; then
-        log_error_and_exit "Failed to set ownership on $daemon_dest"
-    fi
-    if ! $SUDO chmod 644 "$daemon_dest"; then
-        log_error_and_exit "Failed to set permissions on $daemon_dest"
-    fi
-    log_message "Set ownership (root:wheel) and permissions (644) on: $daemon_dest"
-    
-    start_daemon
+    _deploy_files
     log_message "Installation completed successfully"
 }
 
@@ -237,39 +218,10 @@ uninstall_components() {
 #
 update_components() {
     log_message "Starting update..."
-    
     configure_sudo
     validate_source_files
     stop_daemon
-    
-    # Update wireless script
-    local wireless_dest="${NETBASICS_PATH}/${WIRELESS_SCRIPT}"
-    if ! $SUDO cp "$WIRELESS_SCRIPT" "$wireless_dest"; then
-        log_error_and_exit "Failed to update $wireless_dest"
-    fi
-    log_message "Updated: $wireless_dest"
-    
-    # Set script permissions
-    if ! $SUDO chmod 755 "$wireless_dest"; then
-        log_error_and_exit "Failed to set permissions on $wireless_dest"
-    fi
-    
-    # Update LaunchDaemon plist
-    local daemon_dest="${LAUNCHDAEMONS_PATH}/${DAEMON_PLIST}"
-    if ! $SUDO cp "$DAEMON_PLIST" "$daemon_dest"; then
-        log_error_and_exit "Failed to update $daemon_dest"
-    fi
-    log_message "Updated: $daemon_dest"
-    
-    # Set plist ownership and permissions (644 required for launchctl to load)
-    if ! $SUDO chown root:wheel "$daemon_dest"; then
-        log_error_and_exit "Failed to set ownership on $daemon_dest"
-    fi
-    if ! $SUDO chmod 644 "$daemon_dest"; then
-        log_error_and_exit "Failed to set permissions on $daemon_dest"
-    fi
-    
-    start_daemon
+    _deploy_files
     log_message "Update completed successfully"
 }
 

--- a/wireless.sh
+++ b/wireless.sh
@@ -12,14 +12,12 @@
 set -euo pipefail  # Exit on error, undefined variables, and pipe failures
 
 # Constants
-readonly SCRIPT_NAME="wireless.sh"
+readonly SCRIPT_NAME="$(basename "$0")"
 readonly SUPPORTED_ADAPTERS="Ethernet|LAN|Thunderbolt|AX88179A"
 readonly SUPPORTED_OS_VERSIONS="23|24|25"  # Sonoma, Sequoia, Tahoe
 readonly LOOP_PREVENTION_DELAY=10
 
 # Global variables
-IPFOUND=""
-OSVERSION=""
 INTERFACES=""
 WIFIINTERFACES=""
 
@@ -38,7 +36,7 @@ log_message() {
 # Returns: OS version number (23, 24, 25, etc.)
 #
 get_os_version() {
-    uname -a | awk '{print $3}' | awk 'BEGIN {FS = "."} ; {print $1}'
+    uname -r | cut -d. -f1
 }
 
 #
@@ -75,11 +73,7 @@ get_wifi_interfaces() {
 #
 get_interface_ip() {
     local interface="$1"
-    
-    if [[ -z "$interface" ]]; then
-        return 1
-    fi
-    
+
     # Get IP address, excluding loopback and self-assigned addresses
     local ip_result
     ip_result=$(ifconfig "$interface" 2>/dev/null | \
@@ -93,37 +87,32 @@ get_interface_ip() {
 
 #
 # Check if any wired interface has a valid IP address
-# Sets global IPFOUND variable to "true" if found
+# Returns: 0 if wired connection found, 1 otherwise
 #
 detect_wired_connection() {
-    IPFOUND=""
-    
     log_message "Starting wired connection detection..."
-    
+
     if [[ -z "$INTERFACES" ]]; then
         log_message "No wired interfaces detected"
-        return 0
+        return 1
     fi
-    
+
     log_message "Checking interfaces: $INTERFACES"
-    
+
     for interface in $INTERFACES; do
         log_message "Checking interface: $interface"
         local ip_address
         ip_address=$(get_interface_ip "$interface")
-        
+
         if [[ -n "$ip_address" ]]; then
-            IPFOUND="true"
             log_message "Active wired connection detected on interface $interface with IP $ip_address"
-            break
-        else
-            log_message "No IP found on interface $interface"
+            return 0
         fi
+        log_message "No IP found on interface $interface"
     done
-    
-    if [[ -z "$IPFOUND" ]]; then
-        log_message "No active wired connections detected"
-    fi
+
+    log_message "No active wired connections detected"
+    return 1
 }
 
 #
@@ -164,6 +153,7 @@ main() {
     log_message "Starting network detection and WiFi management"
     
     # Get system information
+    local OSVERSION
     OSVERSION=$(get_os_version)
     log_message "Detected macOS version: $OSVERSION"
     
@@ -180,11 +170,8 @@ main() {
     log_message "Detected wired interfaces: ${INTERFACES:-none}"
     log_message "Detected WiFi interfaces: ${WIFIINTERFACES:-none}"
     
-    # Detect wired connection status
-    detect_wired_connection
-    
-    # Manage WiFi state based on wired connection
-    if [[ -n "$IPFOUND" ]]; then
+    # Detect wired connection and manage WiFi state
+    if detect_wired_connection; then
         toggle_wifi "off"
         log_message "WiFi disabled due to active wired connection"
     else

--- a/wireless.sh
+++ b/wireless.sh
@@ -12,7 +12,8 @@
 set -euo pipefail  # Exit on error, undefined variables, and pipe failures
 
 # Constants
-readonly SCRIPT_NAME="$(basename "$0")"
+SCRIPT_NAME="$(basename "$0")"
+readonly SCRIPT_NAME
 readonly SUPPORTED_ADAPTERS="Ethernet|LAN|Thunderbolt|AX88179A"
 readonly SUPPORTED_OS_VERSIONS="23|24|25"  # Sonoma, Sequoia, Tahoe
 readonly LOOP_PREVENTION_DELAY=10


### PR DESCRIPTION
## Summary

Six simplification issues addressed in one pass.

### `wireless.sh`
| Issue | Change |
|---|---|
| #39 | `SCRIPT_NAME` uses `$(basename "$0")` — no longer goes stale on rename |
| #36 | `get_os_version`: double-awk pipeline → `uname -r \| cut -d. -f1` |
| #37 | Deleted unreachable empty-interface guard in `get_interface_ip` |
| #38 | `detect_wired_connection` returns exit code (0=found, 1=not found); removed `IPFOUND` and `OSVERSION` module-level globals |

### `install.sh`
| Issue | Change |
|---|---|
| #39 | `SCRIPT_NAME` uses `$(basename "$0")` |
| #41 | `validate_source_files`: 13-line array accumulator → 2-line guards |
| #40 | Extracted `_deploy_files` helper, eliminating ~20-line duplication between `install_components` and `update_components` |

Net diff: **-52 lines**.

Closes #36, #37, #38, #39, #40, #41