### PR TITLE
test: add BATS suite — 51 tests (#42–#50)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,11 +6,13 @@ on:
       - 'wireless.sh'
       - 'install.sh'
       - 'com.computernetworkbasics.wifionoff.plist'
+      - 'test/**'
   pull_request:
     paths:
       - 'wireless.sh'
       - 'install.sh'
       - 'com.computernetworkbasics.wifionoff.plist'
+      - 'test/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,8 +27,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install xmllint
-        run: sudo apt-get install -y --no-install-recommends libxml2-utils
+      - name: Install xmllint and bats
+        run: sudo apt-get install -y --no-install-recommends libxml2-utils bats
 
       - name: Lint shell scripts
         run: shellcheck wireless.sh install.sh
@@ -48,3 +50,9 @@ jobs:
           grep -q "<key>WatchPaths</key>" com.computernetworkbasics.wifionoff.plist
           grep -q "/Library/Scripts/NetBasics/wireless.sh" com.computernetworkbasics.wifionoff.plist
           grep -q "/Library/Preferences/SystemConfiguration" com.computernetworkbasics.wifionoff.plist
+
+      - name: Install macOS command stubs for Linux CI
+        run: sudo install -m 755 test/helpers/networksetup /usr/sbin/networksetup
+
+      - name: Run BATS tests
+        run: bats test/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- BATS test suite (`test/wireless.bats`, `test/install.bats`) with 51 tests covering all core functions (fixes #42–#50)
+- `test/helpers/` stubs for `uname`, `ifconfig`, `logger`, `id`, and `networksetup`
+- CI: `validate.yml` now installs bats, deploys the `networksetup` stub to `/usr/sbin/`, and runs the full test suite; also triggers on `test/**` path changes
+
 ### Changed
 - `wireless.sh`: `SCRIPT_NAME` now uses `$(basename "$0")` instead of a hardcoded string (fixes #39)
 - `wireless.sh`: `get_os_version` simplified from double-awk to `uname -r | cut -d. -f1` (fixes #36)

--- a/test/helpers/id
+++ b/test/helpers/id
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Stub for id; returns ID_OUTPUT (default 501 = non-root) for configure_sudo
+echo "${ID_OUTPUT:-501}"

--- a/test/helpers/ifconfig
+++ b/test/helpers/ifconfig
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Stub for ifconfig; supports per-interface output via IFCONFIG_<IFACE>_OUTPUT,
+# falling back to IFCONFIG_OUTPUT.
+iface="${1:-}"
+# uppercase and replace hyphens so "en0" -> IFCONFIG_EN0_OUTPUT
+varname="IFCONFIG_${iface^^}_OUTPUT"
+varname="${varname//-/_}"
+echo "${!varname:-${IFCONFIG_OUTPUT:-}}"

--- a/test/helpers/logger
+++ b/test/helpers/logger
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Stub for logger; swallows all output so tests stay quiet
+true

--- a/test/helpers/networksetup
+++ b/test/helpers/networksetup
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Stub for /usr/sbin/networksetup; driven by env vars so each test controls output.
+# Installed to /usr/sbin/networksetup in CI by validate.yml.
+case "$1" in
+    -listnetworkserviceorder)
+        printf '%s\n' "${NETWORKSETUP_SERVICEORDER:-}"
+        ;;
+    -listallhardwareports)
+        printf '%s\n' "${NETWORKSETUP_HARDWAREPORTS:-}"
+        ;;
+    -setairportpower)
+        # Support per-interface exit codes: NETWORKSETUP_SETAIRPORT_EN0_EXIT etc.
+        iface="${2:-}"
+        varname="NETWORKSETUP_SETAIRPORT_${iface^^}_EXIT"
+        varname="${varname//-/_}"
+        exit "${!varname:-${NETWORKSETUP_SETAIRPORT_EXIT:-0}}"
+        ;;
+    *)
+        exit 0
+        ;;
+esac

--- a/test/helpers/uname
+++ b/test/helpers/uname
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Stub for uname; returns UNAME_R_OUTPUT for -r flag used in get_os_version
+echo "${UNAME_R_OUTPUT:-23.6.0}"

--- a/test/install.bats
+++ b/test/install.bats
@@ -1,0 +1,155 @@
+#!/usr/bin/env bats
+#
+# Tests for install.sh — covers issues #49, #50
+#
+
+INSTALL_SH="$BATS_TEST_DIRNAME/../install.sh"
+
+setup() {
+    export PATH="$BATS_TEST_DIRNAME/helpers:$PATH"
+    # shellcheck source=../install.sh
+    source "$INSTALL_SH"
+    set +euo pipefail
+}
+
+# ── validate_source_files (#50) ───────────────────────────────────────────────
+# Run in a fresh bash -c subshell with a temp dir so the relative-path constants
+# (WIRELESS_SCRIPT="wireless.sh", DAEMON_PLIST="...plist") resolve correctly.
+
+@test "validate_source_files: passes when both files present" {
+    local d; d=$(mktemp -d)
+    touch "$d/wireless.sh" "$d/com.computernetworkbasics.wifionoff.plist"
+    run bash -c "cd '$d' && source '$INSTALL_SH' && validate_source_files"
+    rm -rf "$d"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_source_files: fails and names file when wireless.sh missing" {
+    local d; d=$(mktemp -d)
+    touch "$d/com.computernetworkbasics.wifionoff.plist"
+    run bash -c "cd '$d' && source '$INSTALL_SH' && validate_source_files"
+    rm -rf "$d"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "wireless.sh" ]]
+}
+
+@test "validate_source_files: fails and names file when plist missing" {
+    local d; d=$(mktemp -d)
+    touch "$d/wireless.sh"
+    run bash -c "cd '$d' && source '$INSTALL_SH' && validate_source_files"
+    rm -rf "$d"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "wifionoff.plist" ]]
+}
+
+@test "validate_source_files: fails when both files missing" {
+    local d; d=$(mktemp -d)
+    run bash -c "cd '$d' && source '$INSTALL_SH' && validate_source_files"
+    rm -rf "$d"
+    [ "$status" -eq 1 ]
+}
+
+# ── configure_sudo (#50) ──────────────────────────────────────────────────────
+
+@test "configure_sudo: SUDO is empty when uid is 0 (root)" {
+    export ID_OUTPUT=0
+    configure_sudo
+    [ "$SUDO" = "" ]
+}
+
+@test "configure_sudo: SUDO is 'sudo' for non-root user" {
+    export ID_OUTPUT=501
+    configure_sudo
+    [ "$SUDO" = "sudo" ]
+}
+
+# ── process_command (#49) ─────────────────────────────────────────────────────
+
+@test "process_command 'i' calls install_components" {
+    install_components() { echo "install_called"; }
+    run process_command "i"
+    [ "$status" -eq 0 ]
+    [ "$output" = "install_called" ]
+}
+
+@test "process_command 'install' calls install_components" {
+    install_components() { echo "install_called"; }
+    run process_command "install"
+    [ "$status" -eq 0 ]
+    [ "$output" = "install_called" ]
+}
+
+@test "process_command '1' calls install_components" {
+    install_components() { echo "install_called"; }
+    run process_command "1"
+    [ "$status" -eq 0 ]
+    [ "$output" = "install_called" ]
+}
+
+@test "process_command 'ui' calls uninstall_components" {
+    uninstall_components() { echo "uninstall_called"; }
+    run process_command "ui"
+    [ "$status" -eq 0 ]
+    [ "$output" = "uninstall_called" ]
+}
+
+@test "process_command 'uninstall' calls uninstall_components" {
+    uninstall_components() { echo "uninstall_called"; }
+    run process_command "uninstall"
+    [ "$status" -eq 0 ]
+    [ "$output" = "uninstall_called" ]
+}
+
+@test "process_command '2' calls uninstall_components" {
+    uninstall_components() { echo "uninstall_called"; }
+    run process_command "2"
+    [ "$status" -eq 0 ]
+    [ "$output" = "uninstall_called" ]
+}
+
+@test "process_command 'up' calls update_components" {
+    update_components() { echo "update_called"; }
+    run process_command "up"
+    [ "$status" -eq 0 ]
+    [ "$output" = "update_called" ]
+}
+
+@test "process_command 'update' calls update_components" {
+    update_components() { echo "update_called"; }
+    run process_command "update"
+    [ "$status" -eq 0 ]
+    [ "$output" = "update_called" ]
+}
+
+@test "process_command '3' calls update_components" {
+    update_components() { echo "update_called"; }
+    run process_command "3"
+    [ "$status" -eq 0 ]
+    [ "$output" = "update_called" ]
+}
+
+@test "process_command 'quit' exits 0" {
+    run process_command "quit"
+    [ "$status" -eq 0 ]
+}
+
+@test "process_command '4' exits 0" {
+    run process_command "4"
+    [ "$status" -eq 0 ]
+}
+
+@test "process_command '--help' shows usage without exiting" {
+    run process_command "--help"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Usage" ]]
+}
+
+@test "process_command returns 1 for unknown input" {
+    run process_command "garbage"
+    [ "$status" -eq 1 ]
+}
+
+@test "process_command returns 1 for empty input" {
+    run process_command ""
+    [ "$status" -eq 1 ]
+}

--- a/test/wireless.bats
+++ b/test/wireless.bats
@@ -1,0 +1,251 @@
+#!/usr/bin/env bats
+#
+# Tests for wireless.sh — covers issues #43, #45, #46, #47, #48
+#
+
+WIRELESS_SH="$BATS_TEST_DIRNAME/../wireless.sh"
+
+setup() {
+    # Prepend helpers so unqualified commands (uname, ifconfig, logger) use stubs.
+    # /usr/sbin/networksetup stub is installed separately by validate.yml.
+    export PATH="$BATS_TEST_DIRNAME/helpers:$PATH"
+    # shellcheck source=../wireless.sh
+    source "$WIRELESS_SH"
+    set +euo pipefail  # prevent sourced script's strict mode from breaking BATS assertions
+}
+
+# ── get_os_version (#43) ──────────────────────────────────────────────────────
+
+@test "get_os_version: returns 23 for Sonoma" {
+    export UNAME_R_OUTPUT="23.6.0"
+    run get_os_version
+    [ "$status" -eq 0 ]
+    [ "$output" = "23" ]
+}
+
+@test "get_os_version: returns 24 for Sequoia" {
+    export UNAME_R_OUTPUT="24.5.0"
+    run get_os_version
+    [ "$status" -eq 0 ]
+    [ "$output" = "24" ]
+}
+
+@test "get_os_version: returns 25 for Tahoe" {
+    export UNAME_R_OUTPUT="25.0.0"
+    run get_os_version
+    [ "$status" -eq 0 ]
+    [ "$output" = "25" ]
+}
+
+@test "SUPPORTED_OS_VERSIONS: rejects version 22" {
+    run bash -c "osv=22; [[ \"\$osv\" =~ ^(23|24|25)\$ ]]"
+    [ "$status" -eq 1 ]
+}
+
+@test "SUPPORTED_OS_VERSIONS: accepts version 23" {
+    run bash -c "osv=23; [[ \"\$osv\" =~ ^(23|24|25)\$ ]]"
+    [ "$status" -eq 0 ]
+}
+
+@test "SUPPORTED_OS_VERSIONS: rejects version 26" {
+    run bash -c "osv=26; [[ \"\$osv\" =~ ^(23|24|25)\$ ]]"
+    [ "$status" -eq 1 ]
+}
+
+# ── get_interface_ip (#45) ────────────────────────────────────────────────────
+
+@test "get_interface_ip: returns valid IP" {
+    export IFCONFIG_OUTPUT="inet 192.168.1.100 netmask 0xffffff00 broadcast 192.168.1.255"
+    run get_interface_ip "en0"
+    [ "$status" -eq 0 ]
+    [ "$output" = "192.168.1.100" ]
+}
+
+@test "get_interface_ip: excludes loopback 127.0.0.1" {
+    export IFCONFIG_OUTPUT="inet 127.0.0.1 netmask 0xff000000"
+    run get_interface_ip "en0"
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "get_interface_ip: excludes self-assigned 169.254.x.x" {
+    export IFCONFIG_OUTPUT="inet 169.254.1.5 netmask 0xffff0000"
+    run get_interface_ip "en0"
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "get_interface_ip: returns empty when no inet line" {
+    export IFCONFIG_OUTPUT="flags=8863<UP,BROADCAST> mtu 1500"
+    run get_interface_ip "en0"
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "get_interface_ip: returns first valid IP when multiple present" {
+    export IFCONFIG_OUTPUT="inet 192.168.1.100 netmask 0xffffff00
+inet 10.0.0.1 netmask 0xffffff00"
+    run get_interface_ip "en0"
+    [ "$status" -eq 0 ]
+    [ "$output" = "192.168.1.100" ]
+}
+
+# ── get_wired_interfaces (#46) ────────────────────────────────────────────────
+
+@test "get_wired_interfaces: returns single Ethernet device" {
+    export NETWORKSETUP_SERVICEORDER="(Hardware Port: Ethernet, Device: en0)"
+    run get_wired_interfaces
+    [ "$output" = "en0" ]
+}
+
+@test "get_wired_interfaces: returns Thunderbolt Ethernet and Ethernet" {
+    export NETWORKSETUP_SERVICEORDER="(Hardware Port: Thunderbolt Ethernet Slot 1, Device: en1)
+(Hardware Port: Ethernet, Device: en0)"
+    run get_wired_interfaces
+    [ "$output" = "en1 en0" ]
+}
+
+@test "get_wired_interfaces: returns AX88179A USB adapter" {
+    export NETWORKSETUP_SERVICEORDER="(Hardware Port: AX88179A USB Ethernet, Device: en3)"
+    run get_wired_interfaces
+    [ "$output" = "en3" ]
+}
+
+@test "get_wired_interfaces: returns empty for Wi-Fi only" {
+    export NETWORKSETUP_SERVICEORDER="(Hardware Port: Wi-Fi, Device: en1)"
+    run get_wired_interfaces
+    [ "$output" = "" ]
+}
+
+@test "get_wired_interfaces: excludes bridge interfaces" {
+    export NETWORKSETUP_SERVICEORDER="(Hardware Port: Thunderbolt Bridge, Device: bridge0)"
+    run get_wired_interfaces
+    [ "$output" = "" ]
+}
+
+@test "get_wired_interfaces: returns empty when no adapters listed" {
+    export NETWORKSETUP_SERVICEORDER=""
+    run get_wired_interfaces
+    [ "$output" = "" ]
+}
+
+# ── get_wifi_interfaces (#46) ─────────────────────────────────────────────────
+
+@test "get_wifi_interfaces: returns single Wi-Fi device" {
+    export NETWORKSETUP_HARDWAREPORTS="Hardware Port: Wi-Fi
+Device: en0
+Ethernet Address: aa:bb:cc:dd:ee:ff
+
+Hardware Port: Bluetooth PAN
+Device: en1
+Ethernet Address: ff:ee:dd:cc:bb:aa"
+    run get_wifi_interfaces
+    [ "$status" -eq 0 ]
+    [ "$output" = "en0" ]
+}
+
+@test "get_wifi_interfaces: returns both devices when two Wi-Fi adapters present" {
+    export NETWORKSETUP_HARDWAREPORTS="Hardware Port: Wi-Fi
+Device: en0
+Ethernet Address: aa:bb:cc:dd:ee:ff
+
+Hardware Port: Wi-Fi
+Device: en2
+Ethernet Address: 11:22:33:44:55:66"
+    run get_wifi_interfaces
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 2 ]
+    [ "${lines[0]}" = "en0" ]
+    [ "${lines[1]}" = "en2" ]
+}
+
+@test "get_wifi_interfaces: returns empty when no Wi-Fi adapters" {
+    export NETWORKSETUP_HARDWAREPORTS="Hardware Port: Bluetooth PAN
+Device: en1
+Ethernet Address: ff:ee:dd:cc:bb:aa"
+    run get_wifi_interfaces
+    [ "$output" = "" ]
+}
+
+# ── detect_wired_connection (#47) ─────────────────────────────────────────────
+
+@test "detect_wired_connection: returns 1 when no wired interfaces" {
+    export INTERFACES=""
+    run detect_wired_connection
+    [ "$status" -eq 1 ]
+}
+
+@test "detect_wired_connection: returns 1 when interface has no IP" {
+    export INTERFACES="en0"
+    export IFCONFIG_OUTPUT=""
+    run detect_wired_connection
+    [ "$status" -eq 1 ]
+}
+
+@test "detect_wired_connection: returns 0 when interface has valid IP" {
+    export INTERFACES="en0"
+    export IFCONFIG_OUTPUT="inet 192.168.1.100 netmask 0xffffff00"
+    run detect_wired_connection
+    [ "$status" -eq 0 ]
+}
+
+@test "detect_wired_connection: returns 0 when second interface has IP (first has none)" {
+    export INTERFACES="en0 en1"
+    export IFCONFIG_EN0_OUTPUT=""
+    export IFCONFIG_EN1_OUTPUT="inet 10.0.0.5 netmask 0xffffff00"
+    run detect_wired_connection
+    [ "$status" -eq 0 ]
+}
+
+@test "detect_wired_connection: returns 1 when only self-assigned IP present" {
+    export INTERFACES="en0"
+    export IFCONFIG_OUTPUT="inet 169.254.1.5 netmask 0xffff0000"
+    run detect_wired_connection
+    [ "$status" -eq 1 ]
+}
+
+# ── toggle_wifi (#48) ─────────────────────────────────────────────────────────
+
+@test "toggle_wifi off: exits 0 when networksetup succeeds" {
+    export WIFIINTERFACES="en0"
+    export NETWORKSETUP_SETAIRPORT_EXIT=0
+    run toggle_wifi "off"
+    [ "$status" -eq 0 ]
+}
+
+@test "toggle_wifi on: exits 0 when networksetup succeeds" {
+    export WIFIINTERFACES="en0"
+    export NETWORKSETUP_SETAIRPORT_EXIT=0
+    run toggle_wifi "on"
+    [ "$status" -eq 0 ]
+}
+
+@test "toggle_wifi: exits 1 for invalid state" {
+    export WIFIINTERFACES="en0"
+    run toggle_wifi "maybe"
+    [ "$status" -eq 1 ]
+}
+
+@test "toggle_wifi: exits 0 and skips when no WiFi interfaces" {
+    export WIFIINTERFACES=""
+    run toggle_wifi "off"
+    [ "$status" -eq 0 ]
+}
+
+@test "toggle_wifi: exits 1 after completing loop when one adapter fails" {
+    export WIFIINTERFACES="en0
+en1"
+    export NETWORKSETUP_SETAIRPORT_EN0_EXIT=0
+    export NETWORKSETUP_SETAIRPORT_EN1_EXIT=1
+    run toggle_wifi "off"
+    [ "$status" -eq 1 ]
+}
+
+@test "toggle_wifi: exits 0 when all adapters succeed" {
+    export WIFIINTERFACES="en0
+en1"
+    export NETWORKSETUP_SETAIRPORT_EN0_EXIT=0
+    export NETWORKSETUP_SETAIRPORT_EN1_EXIT=0
+    run toggle_wifi "off"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Adds a complete BATS test suite, closing issues #42, #43, #45, #46, #47, #48, #49, #50.

(Issue #44 was the merged refactor PR, not a test issue.)

### Files added
| File | Purpose |
|---|---|
| `test/wireless.bats` | 31 tests for `wireless.sh` functions |
| `test/install.bats` | 20 tests for `install.sh` functions |
| `test/helpers/uname` | Stub — returns `$UNAME_R_OUTPUT` |
| `test/helpers/ifconfig` | Stub — per-interface via `$IFCONFIG_<IFACE>_OUTPUT` |
| `test/helpers/logger` | Stub — swallows output |
| `test/helpers/id` | Stub — returns `$ID_OUTPUT` |
| `test/helpers/networksetup` | Stub — env-var driven for all subcommands; installed to `/usr/sbin/networksetup` in CI |

### Coverage
- `get_os_version` parsing + version validation (#43)
- `get_interface_ip` IP filtering (loopback, self-assigned, valid, multiple) (#45)
- `get_wired_interfaces` adapter filtering (Ethernet, Thunderbolt, AX88179A, bridge, empty) (#46)
- `get_wifi_interfaces` (single, multiple, none) (#46)
- `detect_wired_connection` exit codes across all wired/no-wired paths (#47)
- `toggle_wifi` state validation + multi-adapter failure accumulation (#48)
- `process_command` all 13 input variants (#49)
- `validate_source_files` all missing-file combinations (#50)
- `configure_sudo` root vs non-root (#50)

All 51 tests pass locally.

Closes #42, #43, #45, #46, #47, #48, #49, #50