### PR TITLE
refactor: remove OS version check (#52)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -41,8 +41,6 @@ jobs:
           grep -q "#!/bin/bash" wireless.sh install.sh
           grep -qE "networksetup.*setairportpower" wireless.sh
           grep -qE "networksetup.*listnetworkserviceorder" wireless.sh
-          grep -qE "uname -r" wireless.sh
-          grep -qE "23\|24\|25" wireless.sh
           grep -q "/Library/Scripts/NetBasics" install.sh
           grep -q "/Library/LaunchDaemons" install.sh
           grep -q "<key>Label</key>" com.computernetworkbasics.wifionoff.plist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,8 @@ There is no automated test suite — the scripts interact with macOS system APIs
 
 1. **shellcheck** — lint `wireless.sh` and `install.sh` for common bash errors
 2. **xmllint** — validate plist XML structure
-3. **Compatibility checks** — verify `SUPPORTED_OS_VERSIONS` constant and `networksetup` usage
+3. **Content checks** — verify `networksetup` usage and install paths
+4. **BATS** — 51 unit tests for all core functions
 
 **Manual testing steps:**
 ```bash
@@ -95,14 +96,13 @@ log show --predicate 'process == "logger"' --last 5m | grep wireless
 ## Key Patterns & Conventions
 
 ### Function Design
-- All functions use `local` variables — no global side-effects except the four module-level globals (`IPFOUND`, `OSVERSION`, `INTERFACES`, `WIFIINTERFACES`) set in `main()`
+- All functions use `local` variables — no global side-effects except the two module-level globals (`INTERFACES`, `WIFIINTERFACES`) set in `main()`
 - Functions return data via `echo`, callers capture with `$(…)`
 - Error paths call `exit 1` — LaunchDaemon treats non-zero exit as restart trigger
 
 ### Network Detection Flow
 ```
 main()
-  ├─ get_os_version()        → validates against SUPPORTED_OS_VERSIONS
   ├─ get_wired_interfaces()  → filters by SUPPORTED_ADAPTERS, excludes "bridge"
   ├─ get_wifi_interfaces()   → greps for "Wi-Fi" in hardware ports
   ├─ detect_wired_connection()
@@ -113,7 +113,6 @@ main()
 
 ### Constants (top of `wireless.sh`)
 - `SUPPORTED_ADAPTERS` — pipe-delimited regex: `"Ethernet|LAN|Thunderbolt|AX88179A"`
-- `SUPPORTED_OS_VERSIONS` — pipe-delimited kernel majors: `"23|24|25"`
 - `LOOP_PREVENTION_DELAY` — seconds to sleep at end (prevents LaunchDaemon restart loop): `10`
 
 ### LaunchDaemon Behavior
@@ -143,13 +142,7 @@ When a new USB/Thunderbolt adapter type needs to be supported:
 
 ## Adding New macOS Version Support
 
-When a new macOS version ships:
-
-1. Update `SUPPORTED_OS_VERSIONS` in `wireless.sh` with new kernel major (e.g., `26` for next release)
-2. Update README badges: `macOS-Sonoma%20|%20Sequoia%20|%20Tahoe` string
-3. Update `release.yml` compatibility notes in the release notes template (lines ~117–119)
-4. Update `validate.yml` macOS version check comment
-5. Update `.github/copilot-instructions.md` Compatibility Notes line (mentions supported OS versions inline)
+No code change required — the OS version check was removed. The script works on any macOS with `networksetup`. Update only documentation (README badge, CHANGELOG) when confirming compatibility with a new release.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- `wireless.sh`: removed `get_os_version()`, `SUPPORTED_OS_VERSIONS` constant, and the runtime OS version check from `main()` — the check was a killswitch that would block future macOS versions despite `networksetup` still working (fixes #52)
+
+### Changed
+- `test/wireless.bats`: removed 6 now-obsolete OS version tests
+- `validate.yml`: removed `uname -r` and `23|24|25` content checks
+- `AGENTS.md`: updated flow diagram, constants list, and "Adding New macOS Version Support" section
+
 ### Added
 - BATS test suite (`test/wireless.bats`, `test/install.bats`) with 51 tests covering all core functions (fixes #42–#50)
 - `test/helpers/` stubs for `uname`, `ifconfig`, `logger`, `id`, and `networksetup`

--- a/test/wireless.bats
+++ b/test/wireless.bats
@@ -14,44 +14,6 @@ setup() {
     set +euo pipefail  # prevent sourced script's strict mode from breaking BATS assertions
 }
 
-# ── get_os_version (#43) ──────────────────────────────────────────────────────
-
-@test "get_os_version: returns 23 for Sonoma" {
-    export UNAME_R_OUTPUT="23.6.0"
-    run get_os_version
-    [ "$status" -eq 0 ]
-    [ "$output" = "23" ]
-}
-
-@test "get_os_version: returns 24 for Sequoia" {
-    export UNAME_R_OUTPUT="24.5.0"
-    run get_os_version
-    [ "$status" -eq 0 ]
-    [ "$output" = "24" ]
-}
-
-@test "get_os_version: returns 25 for Tahoe" {
-    export UNAME_R_OUTPUT="25.0.0"
-    run get_os_version
-    [ "$status" -eq 0 ]
-    [ "$output" = "25" ]
-}
-
-@test "SUPPORTED_OS_VERSIONS: rejects version 22" {
-    run bash -c "osv=22; [[ \"\$osv\" =~ ^(23|24|25)\$ ]]"
-    [ "$status" -eq 1 ]
-}
-
-@test "SUPPORTED_OS_VERSIONS: accepts version 23" {
-    run bash -c "osv=23; [[ \"\$osv\" =~ ^(23|24|25)\$ ]]"
-    [ "$status" -eq 0 ]
-}
-
-@test "SUPPORTED_OS_VERSIONS: rejects version 26" {
-    run bash -c "osv=26; [[ \"\$osv\" =~ ^(23|24|25)\$ ]]"
-    [ "$status" -eq 1 ]
-}
-
 # ── get_interface_ip (#45) ────────────────────────────────────────────────────
 
 @test "get_interface_ip: returns valid IP" {

--- a/wireless.sh
+++ b/wireless.sh
@@ -15,7 +15,6 @@ set -euo pipefail  # Exit on error, undefined variables, and pipe failures
 SCRIPT_NAME="$(basename "$0")"
 readonly SCRIPT_NAME
 readonly SUPPORTED_ADAPTERS="Ethernet|LAN|Thunderbolt|AX88179A"
-readonly SUPPORTED_OS_VERSIONS="23|24|25"  # Sonoma, Sequoia, Tahoe
 readonly LOOP_PREVENTION_DELAY=10
 
 # Global variables
@@ -30,14 +29,6 @@ log_message() {
     local message="$1"
     logger "${SCRIPT_NAME}: ${message}"
     echo "${SCRIPT_NAME}: ${message}"
-}
-
-#
-# Get the current macOS version number
-# Returns: OS version number (23, 24, 25, etc.)
-#
-get_os_version() {
-    uname -r | cut -d. -f1
 }
 
 #
@@ -152,18 +143,7 @@ toggle_wifi() {
 #
 main() {
     log_message "Starting network detection and WiFi management"
-    
-    # Get system information
-    local OSVERSION
-    OSVERSION=$(get_os_version)
-    log_message "Detected macOS version: $OSVERSION"
-    
-    # Validate OS compatibility
-    if [[ ! "$OSVERSION" =~ ^($SUPPORTED_OS_VERSIONS)$ ]]; then
-        log_message "WARNING: Unsupported macOS version $OSVERSION. Supported versions: Sonoma (23), Sequoia (24), Tahoe (25)"
-        exit 1
-    fi
-    
+
     # Get network interfaces (|| "" guards against set -e killing the script when grep finds no matches)
     INTERFACES=$(get_wired_interfaces) || INTERFACES=""
     WIFIINTERFACES=$(get_wifi_interfaces) || WIFIINTERFACES=""


### PR DESCRIPTION
Fixes #52.

The `SUPPORTED_OS_VERSIONS` check was a self-imposed killswitch: when macOS 26 ships the script silently exits 1, even though `networksetup` and `ifconfig` would work fine. There are no version-specific code paths — the version was fetched, logged, and used only to gate execution.

### Changes
- `wireless.sh`: deleted `get_os_version()`, `SUPPORTED_OS_VERSIONS`, and the version fetch/log/validate block in `main()` (−27 lines)
- `test/wireless.bats`: removed 6 now-obsolete OS version tests (45 tests remain, all passing)
- `validate.yml`: removed `uname -r` and `23|24|25` content checks
- `AGENTS.md`: updated flow diagram, constants list, and "Adding New macOS Version Support" section

Closes #52