### PR TITLE
fix: update CHANGELOG on release (#54)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get latest tag
         id: tag
@@ -34,6 +35,20 @@ jobs:
           V="${{ steps.tag.outputs.latest }}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "${V#v}"
           echo "new=v${MAJOR}.${MINOR}.$((PATCH + 1))" >> $GITHUB_OUTPUT
+
+      - name: Update CHANGELOG
+        run: |
+          NEW="${{ steps.version.outputs.new }}"
+          PREV="${{ steps.tag.outputs.latest }}"
+          YEAR=$(date +%Y)
+          sed -i "s/^## \[Unreleased\]$/## [Unreleased]\n\n## [${NEW#v}] – ${YEAR}/" CHANGELOG.md
+          sed -i "s|/compare/.*\.\.\.HEAD|/compare/${NEW}...HEAD|" CHANGELOG.md
+          sed -i "/^\[Unreleased\]:/a [${NEW#v}]: https://github.com/${{ github.repository }}/compare/${PREV}...${NEW}" CHANGELOG.md
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "chore: update CHANGELOG for ${NEW}"
+          git push
 
       - name: Build archives
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `release.yml`: CHANGELOG.md was never updated on release; workflow now promotes `[Unreleased]` to a versioned entry, updates the comparison link, and commits before tagging (fixes #54)
+
+### Changed
+- `CHANGELOG.md`: backfilled missing comparison links for v1.0.7–v1.0.10
+
 ### Removed
 - `wireless.sh`: removed `get_os_version()`, `SUPPORTED_OS_VERSIONS` constant, and the runtime OS version check from `main()` — the check was a killswitch that would block future macOS versions despite `networksetup` still working (fixes #52)
 
@@ -89,7 +95,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release: `wireless.sh` core logic, `install.sh`, LaunchDaemon plist
 - Supports Ethernet, Thunderbolt, LAN, and AX88179A (USB-C) adapters
 
-[Unreleased]: https://github.com/locus313/macos-wireless-autoswitch/compare/v1.0.6...HEAD
+[Unreleased]: https://github.com/locus313/macos-wireless-autoswitch/compare/v1.0.10...HEAD
+[1.0.10]: https://github.com/locus313/macos-wireless-autoswitch/compare/v1.0.9...v1.0.10
+[1.0.9]: https://github.com/locus313/macos-wireless-autoswitch/compare/v1.0.8...v1.0.9
+[1.0.8]: https://github.com/locus313/macos-wireless-autoswitch/compare/v1.0.7...v1.0.8
+[1.0.7]: https://github.com/locus313/macos-wireless-autoswitch/compare/v1.0.6...v1.0.7
 [1.0.6]: https://github.com/locus313/macos-wireless-autoswitch/compare/v1.0.5...v1.0.6
 [1.0.5]: https://github.com/locus313/macos-wireless-autoswitch/compare/v1.0.4...v1.0.5
 [1.0.4]: https://github.com/locus313/macos-wireless-autoswitch/compare/v1.0.3...v1.0.4


### PR DESCRIPTION
Fixes #54.

### Problem
`release.yml` never touched `CHANGELOG.md`, so each release shipped with a stale changelog: `[Unreleased]` still contained changes, no dated versioned entry was created, and comparison links were never added.

### Fix
New **Update CHANGELOG** step (runs after version bump, before build+tag):
1. Promotes `## [Unreleased]` to `## [Unreleased]\n\n## [X.Y.Z] – YYYY`
2. Updates the `[Unreleased]:` comparison link to the new tag
3. Inserts the new `[X.Y.Z]:` comparison link
4. Commits and pushes back to main before `gh release create`

Also backfills missing comparison links for v1.0.7–v1.0.10 which were never added to CHANGELOG.md.

Closes #54