### PR TITLE
fix: seven cleanup issues (#56–#62)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           NAME="macos-wireless-autoswitch-${{ steps.version.outputs.new }}"
           mkdir "$NAME"
-          cp wireless.sh install.sh com.computernetworkbasics.wifionoff.plist README.md LICENSE "$NAME/"
+          cp wireless.sh install.sh com.computernetworkbasics.wifionoff.plist README.md LICENSE CHANGELOG.md "$NAME/"
           tar -czf "$NAME.tar.gz" "$NAME"
           zip -r "$NAME.zip" "$NAME"
           echo "ARCHIVE=$NAME" >> $GITHUB_ENV

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,7 +25,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install xmllint and bats
         run: sudo apt-get install -y --no-install-recommends libxml2-utils bats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `wireless.sh`: stale "Sonoma, Sequoia, Tahoe" header comment updated to "macOS 14+" (fixes #56)
+- `install.sh`: `show_help` requirements updated to "macOS 14+"; `launchctl load/unload` replaced with `launchctl bootstrap/bootout` (fixes #56, #57)
+- `wireless.sh`: `get_wired_interfaces()` now returns newline-separated output (dropped `tr`/`sed` trim); `detect_wired_connection()` iterates with `while IFS= read -r` to match `toggle_wifi` (fixes #58)
+- `wireless.sh`: removed dead `2>/dev/null` from `head -1` in `get_interface_ip()` (fixes #62)
+- `com.computernetworkbasics.wifionoff.plist`: `ThrottleInterval` bumped from 5 to 10 to match `LOOP_PREVENTION_DELAY` (fixes #61)
+- `release.yml`: added `CHANGELOG.md` to release archive (fixes #59)
+- `validate.yml`: standardised `actions/checkout` to `@v7` to match `release.yml` (fixes #60)
+
+### Fixed
 - `release.yml`: CHANGELOG.md was never updated on release; workflow now promotes `[Unreleased]` to a versioned entry, updates the comparison link, and commits before tagging (fixes #54)
 
 ### Changed

--- a/com.computernetworkbasics.wifionoff.plist
+++ b/com.computernetworkbasics.wifionoff.plist
@@ -28,6 +28,6 @@
     <false/>
     
     <key>ThrottleInterval</key>
-    <integer>5</integer>
+    <integer>10</integer>
 </dict>
 </plist>

--- a/install.sh
+++ b/install.sh
@@ -109,7 +109,7 @@ stop_daemon() {
     
     if [[ -f "$daemon_path" ]]; then
         log_message "Stopping LaunchDaemon..."
-        if $SUDO launchctl unload "$daemon_path" 2>/dev/null; then
+        if $SUDO launchctl bootout system "$daemon_path" 2>/dev/null; then
             log_message "LaunchDaemon stopped successfully"
         else
             log_message "LaunchDaemon was not running or failed to stop (this is normal)"
@@ -125,7 +125,7 @@ start_daemon() {
     
     if [[ -f "$daemon_path" ]]; then
         log_message "Starting LaunchDaemon..."
-        if $SUDO launchctl load "$daemon_path"; then
+        if $SUDO launchctl bootstrap system "$daemon_path"; then
             log_message "LaunchDaemon started successfully"
         else
             log_error_and_exit "Failed to start LaunchDaemon"
@@ -251,7 +251,7 @@ Examples:
 
 Requirements:
   - Administrator privileges (sudo access)
-  - macOS Sonoma (14.x), Sequoia (15.x), or Tahoe (16.x)
+  - macOS 14+
   - Source files: $WIRELESS_SCRIPT, $DAEMON_PLIST
 
 For more information, see the project documentation.

--- a/test/wireless.bats
+++ b/test/wireless.bats
@@ -64,7 +64,9 @@ inet 10.0.0.1 netmask 0xffffff00"
     export NETWORKSETUP_SERVICEORDER="(Hardware Port: Thunderbolt Ethernet Slot 1, Device: en1)
 (Hardware Port: Ethernet, Device: en0)"
     run get_wired_interfaces
-    [ "$output" = "en1 en0" ]
+    [ "${#lines[@]}" -eq 2 ]
+    [ "${lines[0]}" = "en1" ]
+    [ "${lines[1]}" = "en0" ]
 }
 
 @test "get_wired_interfaces: returns AX88179A USB adapter" {
@@ -152,7 +154,8 @@ Ethernet Address: ff:ee:dd:cc:bb:aa"
 }
 
 @test "detect_wired_connection: returns 0 when second interface has IP (first has none)" {
-    export INTERFACES="en0 en1"
+    export INTERFACES="en0
+en1"
     export IFCONFIG_EN0_OUTPUT=""
     export IFCONFIG_EN1_OUTPUT="inet 10.0.0.5 netmask 0xffffff00"
     run detect_wired_connection

--- a/wireless.sh
+++ b/wireless.sh
@@ -3,7 +3,7 @@
 #
 # macOS Wireless Auto-Switch Utility
 # Automatically toggles WiFi off when wired Ethernet connection is detected
-# and back on when disconnected. Supports Sonoma, Sequoia, and Tahoe.
+# and back on when disconnected. Supports macOS 14+.
 #
 # Requirements: Root privileges, macOS 14+, Bash 4+
 # Usage: Executed automatically by LaunchDaemon on network configuration changes
@@ -41,9 +41,7 @@ get_wired_interfaces() {
         grep -E "${SUPPORTED_ADAPTERS}" | \
         awk -F ": " '{print $3}' | \
         sed 's/)//g' | \
-        grep -v "bridge" | \
-        tr '\n' ' ' | \
-        sed 's/[[:space:]]*$//'
+        grep -v "bridge"
 }
 
 #
@@ -72,8 +70,7 @@ get_interface_ip() {
         grep -E 'inet [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | \
         grep -E -v '127\.0\.0\.1|169\.254\.' | \
         awk '{print $2}' | \
-        head -1 2>/dev/null)
-    
+        head -1)
     echo "$ip_result"
 }
 
@@ -91,7 +88,8 @@ detect_wired_connection() {
 
     log_message "Checking interfaces: $INTERFACES"
 
-    for interface in $INTERFACES; do
+    while IFS= read -r interface; do
+        [[ -z "$interface" ]] && continue
         log_message "Checking interface: $interface"
         local ip_address
         ip_address=$(get_interface_ip "$interface")
@@ -101,7 +99,7 @@ detect_wired_connection() {
             return 0
         fi
         log_message "No IP found on interface $interface"
-    done
+    done <<< "$INTERFACES"
 
     log_message "No active wired connections detected"
     return 1


### PR DESCRIPTION
## Summary

| Issue | File | Fix |
|---|---|---|
| #56 | `wireless.sh`, `install.sh` | Stale macOS version names → "macOS 14+" |
| #57 | `install.sh` | `launchctl load/unload` → `bootstrap/bootout` |
| #58 | `wireless.sh` | `get_wired_interfaces` now returns newline-separated; `detect_wired_connection` uses `while IFS= read -r` |
| #59 | `release.yml` | `CHANGELOG.md` added to release archive |
| #60 | `validate.yml` | `actions/checkout@v4` → `@v7` to match `release.yml` |
| #61 | `*.plist` | `ThrottleInterval` 5 → 10 to match `LOOP_PREVENTION_DELAY` |
| #62 | `wireless.sh` | Removed dead `2>/dev/null` from `head -1` |

All 45 BATS tests pass.

Closes #56, #57, #58, #59, #60, #61, #62