### PR TITLE
docs: backfill CHANGELOG with correct versions for v1.0.7–v1.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Migrated release workflow to `googleapis/release-please-action@v4`; releases now go through a PR instead of pushing directly to `main` (fixes protected branch failure)
+
 ### Fixed
 - `wireless.sh`: stale "Sonoma, Sequoia, Tahoe" header comment updated to "macOS 14+" (fixes #56)
 - `install.sh`: `show_help` requirements updated to "macOS 14+"; `launchctl load/unload` replaced with `launchctl bootstrap/bootout` (fixes #56, #57)
-- `wireless.sh`: `get_wired_interfaces()` now returns newline-separated output (dropped `tr`/`sed` trim); `detect_wired_connection()` iterates with `while IFS= read -r` to match `toggle_wifi` (fixes #58)
+- `wireless.sh`: `get_wired_interfaces()` now returns newline-separated output; `detect_wired_connection()` iterates with `while IFS= read -r` to match `toggle_wifi` (fixes #58)
 - `wireless.sh`: removed dead `2>/dev/null` from `head -1` in `get_interface_ip()` (fixes #62)
 - `com.computernetworkbasics.wifionoff.plist`: `ThrottleInterval` bumped from 5 to 10 to match `LOOP_PREVENTION_DELAY` (fixes #61)
 - `release.yml`: added `CHANGELOG.md` to release archive (fixes #59)
-- `validate.yml`: standardised `actions/checkout` to `@v7` to match `release.yml` (fixes #60)
+- `validate.yml` / `release.yml`: standardised `actions/checkout` to `@v7` (fixes #60)
+- `release.yml`: CHANGELOG was never updated on release; replaced with release-please (fixes #54)
 
-### Fixed
-- `release.yml`: CHANGELOG.md was never updated on release; workflow now promotes `[Unreleased]` to a versioned entry, updates the comparison link, and commits before tagging (fixes #54)
-
-### Changed
-- `CHANGELOG.md`: backfilled missing comparison links for v1.0.7–v1.0.10
+## [1.0.10] – 2026-07-13
 
 ### Removed
-- `wireless.sh`: removed `get_os_version()`, `SUPPORTED_OS_VERSIONS` constant, and the runtime OS version check from `main()` — the check was a killswitch that would block future macOS versions despite `networksetup` still working (fixes #52)
+- `wireless.sh`: removed `get_os_version()`, `SUPPORTED_OS_VERSIONS` constant, and the runtime OS version check — the check was a killswitch that blocked future macOS versions despite `networksetup` still working (fixes #52)
 
 ### Changed
 - `test/wireless.bats`: removed 6 now-obsolete OS version tests
@@ -35,29 +35,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `test/helpers/` stubs for `uname`, `ifconfig`, `logger`, `id`, and `networksetup`
 - CI: `validate.yml` now installs bats, deploys the `networksetup` stub to `/usr/sbin/`, and runs the full test suite; also triggers on `test/**` path changes
 
+## [1.0.9] – 2026-07-13
+
 ### Changed
 - `wireless.sh`: `SCRIPT_NAME` now uses `$(basename "$0")` instead of a hardcoded string (fixes #39)
 - `wireless.sh`: `get_os_version` simplified from double-awk to `uname -r | cut -d. -f1` (fixes #36)
 - `wireless.sh`: removed unreachable empty-interface guard in `get_interface_ip` (fixes #37)
-- `wireless.sh`: `detect_wired_connection` now returns exit code (0=found, 1=not found) instead of setting `IPFOUND` global; removed `IPFOUND`/`OSVERSION` module-level globals (fixes #38)
+- `wireless.sh`: `detect_wired_connection` now returns exit code (0=found, 1=not found) instead of setting `IPFOUND` global; removed module-level globals (fixes #38)
 - `install.sh`: `SCRIPT_NAME` now uses `$(basename "$0")` instead of a hardcoded string (fixes #39)
 - `install.sh`: `validate_source_files` simplified from 13-line array accumulator to 2-line guards (fixes #41)
 - `install.sh`: extracted `_deploy_files` helper to eliminate ~20-line duplication between `install_components` and `update_components` (fixes #40)
 
 ### Added
-- `.github/skills/sync-docs`: new Copilot skill that audits `AGENTS.md` and `.github/copilot-instructions.md` against the live source, patches stale values, updates `CHANGELOG.md [Unreleased]`, then commits and pushes
+- `.github/skills/sync-docs`: new Copilot skill that audits `AGENTS.md` and `copilot-instructions.md`, patches stale values, updates `CHANGELOG.md [Unreleased]`, then commits and pushes
+- CI: simplified and modernised `validate.yml` and `release.yml` workflows (#35)
+
+## [1.0.8] – 2026-07-12
 
 ### Fixed
 - `wireless.sh`: `toggle_wifi` mid-loop `exit 1` left multi-adapter Macs in a split WiFi state; loop now completes all interfaces before exiting non-zero (fixes #32)
 - `com.computernetworkbasics.wifionoff.plist`: `RunAtLoad: false` meant booting with Ethernet already connected never triggered the daemon; changed to `true` (fixes #31)
 - `install.sh`: bare filenames resolved against `$PWD` caused "Missing required files" when not run from the repo directory; `main()` now `cd`s to script directory first (fixes #30)
 
+## [1.0.7] – 2026-07-12
+
 ### Fixed
-- `wireless.sh`: `set -e` + empty grep silently killed the script before WiFi could be re-enabled; bare assignments now use `|| INTERFACES=""` / `|| WIFIINTERFACES=""` guards (fixes #27)
+- `wireless.sh`: `set -e` + empty grep silently killed the script before WiFi could be re-enabled; assignments now use `|| INTERFACES=""` / `|| WIFIINTERFACES=""` guards (fixes #27)
 - `wireless.sh`: `toggle_wifi` passed multi-line `$WIFIINTERFACES` as one argument, failing on Macs with multiple WiFi adapters; now iterates per interface (fixes #28)
 - `install.sh`: missing `chmod 644` on installed plist caused `launchctl` to silently refuse loading on systems with a restrictive umask; added to both `install_components` and `update_components` (fixes #26)
 
-## [1.0.6] – 2025
+## [1.0.6] – 2025-09-26
 
 ### Added
 - Copilot agents, instructions, and skills for AI-assisted development


### PR DESCRIPTION
Each item previously lumped in `[Unreleased]` has been moved to its correct versioned section based on the git tag history.

| Section | Commits |
|---|---|
| `[Unreleased]` | #55, #63, #64 (post v1.0.10) |
| `[1.0.10]` | #51, #53 |
| `[1.0.9]` | #44, #34, #35 |
| `[1.0.8]` | #33 |
| `[1.0.7]` | #29 |

Also corrected `[1.0.6]` date from `2025` to `2025-09-26`.