### PR TITLE
feat: agent harness — drift checks, failure memory, fix stale docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,9 +65,11 @@ When you change a file, also update these:
 |---|---|
 | `wireless.sh` — `SUPPORTED_ADAPTERS` | `README.md` adapter list, `validate.yml` adapter grep |
 | `wireless.sh` — `SUPPORTED_OS_VERSIONS` | `README.md` badges + System Requirements, `release.yml` compatibility notes (lines ~117–119), `validate.yml` version check comment, `AGENTS.md` supported macOS table |
-| `wireless.sh` — `LOOP_PREVENTION_DELAY` | `com.computernetworkbasics.wifionoff.plist` `ThrottleInterval` (should match or exceed) |
+| `wireless.sh` — `LOOP_PREVENTION_DELAY` | `com.computernetworkbasics.wifionoff.plist` `ThrottleInterval` (should match or exceed) — `scripts/check_drift.sh` enforces this in CI |
 | `wireless.sh` — any function signature | `AGENTS.md` network detection flow diagram |
-| `install.sh` — install paths | `com.computernetworkbasics.wifionoff.plist` `ProgramArguments`, `validate.yml` path checks, `AGENTS.md` install locations |
+| `install.sh` — install paths | `com.computernetworkbasics.wifionoff.plist` `ProgramArguments`, `validate.yml` path checks, `AGENTS.md` install locations — `scripts/check_drift.sh` enforces this in CI |
 | `com.computernetworkbasics.wifionoff.plist` | `validate.yml` plist key checks, `AGENTS.md` LaunchDaemon behavior notes |
 | Any core file (`wireless.sh`, `install.sh`, `*.plist`) | `CHANGELOG.md` under `[Unreleased]` |
 | `.github/workflows/release.yml` — compatibility notes | Keep in sync with `SUPPORTED_OS_VERSIONS` in `wireless.sh` |
+
+**Failure memory:** `docs/failures/` records past agent mistakes and the checks that prevent recurrence. Read before modifying network detection or install paths.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,12 +7,14 @@ on:
       - 'install.sh'
       - 'com.computernetworkbasics.wifionoff.plist'
       - 'test/**'
+      - 'scripts/**'
   pull_request:
     paths:
       - 'wireless.sh'
       - 'install.sh'
       - 'com.computernetworkbasics.wifionoff.plist'
       - 'test/**'
+      - 'scripts/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -54,3 +56,6 @@ jobs:
 
       - name: Run BATS tests
         run: bats test/
+
+      - name: Run drift checks
+        run: bash scripts/check_drift.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,12 @@ macos-wireless-autoswitch/
 ├── LICENSE                                  # MIT
 ├── README.md
 ├── CHANGELOG.md
+├── scripts/
+│   └── check_drift.sh                       # Drift check: validates maintenance-matrix sync rules
+├── docs/
+│   └── failures/                            # Failure memory: recurring agent mistakes and fixes
+│       ├── launchdaemon-restart-loop.md
+│       └── install-path-desync.md
 └── .github/
     ├── copilot-instructions.md
     ├── workflows/
@@ -62,6 +68,9 @@ sudo /Library/Scripts/NetBasics/wireless.sh
 
 # Lint both shell scripts
 shellcheck wireless.sh install.sh
+
+# Run drift checks (no macOS needed)
+bash scripts/check_drift.sh
 ```
 
 **Install locations (post-install):**
@@ -72,12 +81,13 @@ shellcheck wireless.sh install.sh
 
 ## Testing
 
-There is no automated test suite — the scripts interact with macOS system APIs that cannot run in a Linux CI environment. Validation in CI covers:
+The scripts interact with macOS system APIs that cannot run natively on Linux CI. Validation in CI covers:
 
 1. **shellcheck** — lint `wireless.sh` and `install.sh` for common bash errors
 2. **xmllint** — validate plist XML structure
 3. **Content checks** — verify `networksetup` usage and install paths
-4. **BATS** — 51 unit tests for all core functions
+4. **BATS** — 45 unit tests for all core functions (25 in `test/wireless.bats`, 20 in `test/install.bats`)
+5. **Drift checks** — `scripts/check_drift.sh` verifies maintenance-matrix sync rules
 
 **Manual testing steps:**
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `scripts/check_drift.sh`: drift check script enforcing two maintenance-matrix rules — `LOOP_PREVENTION_DELAY` ≤ `ThrottleInterval`, and `NETBASICS_PATH` present in plist `ProgramArguments`
+- `docs/failures/launchdaemon-restart-loop.md`: failure memory for delay/throttle desync
+- `docs/failures/install-path-desync.md`: failure memory for install path desync between `install.sh` and plist
+- `validate.yml`: added drift check step (`bash scripts/check_drift.sh`) and `scripts/**` path trigger
+
+### Fixed
+- `AGENTS.md`: corrected stale BATS test count (51 → 45); corrected "no automated test suite" contradiction
+
+### Added
 - Migrated release workflow to `googleapis/release-please-action@v4`; releases now go through a PR instead of pushing directly to `main` (fixes protected branch failure)
 
 ### Fixed

--- a/docs/failures/install-path-desync.md
+++ b/docs/failures/install-path-desync.md
@@ -1,0 +1,26 @@
+# Daemon Launch Failure from Install Path Desync
+
+## Summary
+
+The LaunchDaemon silently fails to execute after installation when `NETBASICS_PATH` in `install.sh` and the `ProgramArguments` path in `com.computernetworkbasics.wifionoff.plist` disagree. `launchd` loads the plist successfully (no XML errors) but attempts to run a path that does not exist, leaving WiFi unmanaged with no obvious error in the UI.
+
+## Root Cause
+
+The install path is defined in two separate places:
+
+- `install.sh`: `readonly NETBASICS_PATH="/Library/Scripts/NetBasics"` — used when copying `wireless.sh` to the system.
+- `com.computernetworkbasics.wifionoff.plist`: `<string>/Library/Scripts/NetBasics/wireless.sh</string>` — the path `launchd` launches.
+
+If an agent updates one without the other (e.g., renames the install directory), `launchd` silently fails because the ProgramArguments path does not exist. The daemon appears loaded in `launchctl list` but never runs.
+
+## Prevention
+
+- `scripts/check_drift.sh` — fails CI if `NETBASICS_PATH` from `install.sh` is not found in the plist `ProgramArguments` string.
+- `validate.yml` content check — verifies both `install.sh` and `plist` reference `/Library/Scripts/NetBasics`.
+- Maintenance matrix row: `install.sh — install paths → com.computernetworkbasics.wifionoff.plist ProgramArguments, validate.yml path checks, AGENTS.md install locations`
+
+## Evidence
+
+- `install.sh`: `readonly NETBASICS_PATH="/Library/Scripts/NetBasics"`
+- `com.computernetworkbasics.wifionoff.plist`: `<string>/Library/Scripts/NetBasics/wireless.sh</string>`
+- `validate.yml` content check: `grep -q "/Library/Scripts/NetBasics/wireless.sh" com.computernetworkbasics.wifionoff.plist`

--- a/docs/failures/launchdaemon-restart-loop.md
+++ b/docs/failures/launchdaemon-restart-loop.md
@@ -1,0 +1,22 @@
+# LaunchDaemon Restart Loop from Delay/Throttle Mismatch
+
+## Summary
+
+The LaunchDaemon enters a rapid restart loop when `LOOP_PREVENTION_DELAY` in `wireless.sh` exceeds `ThrottleInterval` in `com.computernetworkbasics.wifionoff.plist`. Each script run triggers another network-configuration event before the sleep completes, causing `launchd` to re-launch the script continuously. This burns CPU and floods system logs.
+
+## Root Cause
+
+`wireless.sh` ends with `sleep $LOOP_PREVENTION_DELAY` to dampen the event-triggered re-launch cycle. `launchd` enforces its own minimum interval between re-launches via `ThrottleInterval`. If `ThrottleInterval < LOOP_PREVENTION_DELAY`, the sleep in the script is the only guard — and any future change that reduces or removes the sleep will cause the loop.
+
+The intended invariant: **`ThrottleInterval` must be ≥ `LOOP_PREVENTION_DELAY`** so both guards are active.
+
+## Prevention
+
+- `scripts/check_drift.sh` — fails CI if `ThrottleInterval` < `LOOP_PREVENTION_DELAY`.
+- Maintenance matrix in `.github/copilot-instructions.md` — documents that changing `LOOP_PREVENTION_DELAY` requires updating `ThrottleInterval` to match or exceed it.
+
+## Evidence
+
+- `wireless.sh`: `readonly LOOP_PREVENTION_DELAY=10`
+- `com.computernetworkbasics.wifionoff.plist`: `<key>ThrottleInterval</key><integer>10</integer>`
+- Maintenance matrix row: `wireless.sh — LOOP_PREVENTION_DELAY → com.computernetworkbasics.wifionoff.plist ThrottleInterval (should match or exceed)`

--- a/scripts/check_drift.sh
+++ b/scripts/check_drift.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Drift check for macos-wireless-autoswitch maintenance-matrix rules.
+# Run locally or in CI to catch silent desync between files.
+#
+# Checks:
+#   1. LOOP_PREVENTION_DELAY (wireless.sh) must match ThrottleInterval (plist)
+#   2. NETBASICS_PATH (install.sh) must appear in plist ProgramArguments
+#
+# Usage: bash scripts/check_drift.sh
+#
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WIRELESS="$ROOT/wireless.sh"
+INSTALL="$ROOT/install.sh"
+PLIST="$ROOT/com.computernetworkbasics.wifionoff.plist"
+
+failures=0
+
+fail() {
+    echo "DRIFT: $1" >&2
+    failures=$((failures + 1))
+}
+
+# ── Check 1: LOOP_PREVENTION_DELAY matches ThrottleInterval ─────────────────
+delay=$(grep -E '^readonly LOOP_PREVENTION_DELAY=' "$WIRELESS" | grep -oE '[0-9]+')
+throttle=$(grep -A1 '<key>ThrottleInterval</key>' "$PLIST" | grep -oE '[0-9]+')
+
+if [[ -z "$delay" ]]; then
+    fail "Could not extract LOOP_PREVENTION_DELAY from wireless.sh"
+elif [[ -z "$throttle" ]]; then
+    fail "Could not extract ThrottleInterval from plist"
+elif [[ "$throttle" -lt "$delay" ]]; then
+    fail "ThrottleInterval ($throttle) < LOOP_PREVENTION_DELAY ($delay) — plist will restart the daemon before the sleep completes, causing a restart loop. See docs/failures/launchdaemon-restart-loop.md"
+else
+    echo "OK: LOOP_PREVENTION_DELAY=$delay, ThrottleInterval=$throttle"
+fi
+
+# ── Check 2: NETBASICS_PATH appears in plist ProgramArguments ────────────────
+netbasics=$(grep -E '^readonly NETBASICS_PATH=' "$INSTALL" | grep -oE '"[^"]+"' | tr -d '"')
+
+if [[ -z "$netbasics" ]]; then
+    fail "Could not extract NETBASICS_PATH from install.sh"
+elif ! grep -qF "$netbasics" "$PLIST"; then
+    fail "NETBASICS_PATH ('$netbasics') not found in plist ProgramArguments — daemon will launch the wrong script path. See docs/failures/install-path-desync.md"
+else
+    echo "OK: NETBASICS_PATH='$netbasics' found in plist"
+fi
+
+# ── Result ───────────────────────────────────────────────────────────────────
+if [[ $failures -gt 0 ]]; then
+    echo ""
+    echo "Drift check failed: $failures issue(s) found." >&2
+    exit 1
+fi
+
+echo ""
+echo "Drift check passed."


### PR DESCRIPTION
## Summary

Adds a lightweight harness to prevent repeated agent mistakes.

### Gaps found
- AGENTS.md said "51 unit tests" — actual count is 45 (25 wireless + 20 install)
- AGENTS.md opened Testing section with "There is no automated test suite" immediately before listing the BATS suite
- Maintenance matrix documents sync rules but nothing enforced them
- Two high-risk footguns had no failure memory

### What was added
- `scripts/check_drift.sh` — enforces two maintenance-matrix rules in CI:
  1. `LOOP_PREVENTION_DELAY` <= plist `ThrottleInterval` (restart loop risk)
  2. `NETBASICS_PATH` from `install.sh` appears in plist `ProgramArguments` (silent daemon launch failure)
- `docs/failures/launchdaemon-restart-loop.md` — failure memory for delay/throttle desync
- `docs/failures/install-path-desync.md` — failure memory for install path desync
- `validate.yml` — added drift check step and `scripts/**` path trigger
- `AGENTS.md` — corrected test count (51 -> 45), fixed contradiction, added drift check command, updated repo structure
- `copilot-instructions.md` — maintenance matrix rows now reference `check_drift.sh` and failure docs
