### PR TITLE
security: pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -7,7 +7,7 @@ jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install shellcheck
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
 
   upload-archives:
@@ -33,15 +33,15 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
       - name: Build and upload archives
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
         run: |
-          TAG="${{ needs.release-please.outputs.tag_name }}"
           NAME="macos-wireless-autoswitch-${TAG}"
           mkdir "$NAME"
           cp wireless.sh install.sh com.computernetworkbasics.wifionoff.plist README.md LICENSE CHANGELOG.md "$NAME/"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,7 +27,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install xmllint and bats
         run: sudo apt-get install -y --no-install-recommends libxml2-utils bats


### PR DESCRIPTION
## Summary

Fixes all three high/medium findings from security review.

### Changes
- **[HIGH]** Pin `googleapis/release-please-action@v4` → `@5c625bfb` (v4.4.1) — mutable tag with `contents: write` was a supply-chain attack vector
- **[MEDIUM]** Move `tag_name` expression from `run:` shell text into `env:` block — eliminates GitHub Actions script injection vector
- **[MEDIUM]** Pin `actions/checkout@v7` → `@9c091bb2` (v7.0.0) across all three workflows

Shell scripts (`wireless.sh`, `install.sh`, `check_drift.sh`) are clean — no changes needed.