### PR TITLE
fix: resolve issues #69, #70, #71, #72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `wireless.sh`: replaced `awk '{print $2}' | head -1` with `awk 'NR==1{print $2; exit}'` in `get_interface_ip()` to prevent SIGPIPE under `pipefail` (#69)
+- `wireless.sh`: replaced fragile `tr`/`sed`/`grep`/`awk` pipeline in `get_wifi_interfaces()` with `awk '/^Hardware Port: Wi-Fi$/{getline; print $2}'` (#72)
+- `install.sh`: `update_components()` now calls `create_directories` before stopping the daemon, preventing failure when directories are missing (#70)
+- `install.sh`: converted `SUDO` string variable to array (`SUDO=()`/`SUDO=(sudo)`) and updated all callsites to `"${SUDO[@]}"` to fix SC2086 and handle spaces safely (#71)
+
 ### Added
 - `scripts/check_drift.sh`: drift check script enforcing two maintenance-matrix rules — `LOOP_PREVENTION_DELAY` ≤ `ThrottleInterval`, and `NETBASICS_PATH` present in plist `ProgramArguments`
 - `docs/failures/launchdaemon-restart-loop.md`: failure memory for delay/throttle desync

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ readonly DAEMON_PLIST="${DAEMON_NAME}.plist"
 readonly WIRELESS_SCRIPT="wireless.sh"
 
 # Global variables
-SUDO=""
+SUDO=()
 
 # Menu options for interactive mode
 readonly PS3='[Please enter your choice]: '
@@ -60,10 +60,10 @@ log_error_and_exit() {
 #
 configure_sudo() {
     if [[ $(id -u) -eq 0 ]]; then
-        SUDO=""
+        SUDO=()
         log_message "Running as root"
     else
-        SUDO="sudo"
+        SUDO=(sudo)
         log_message "Running as non-root user, will use sudo for privileged operations"
     fi
 }
@@ -75,7 +75,7 @@ create_directories() {
     log_message "Creating system directories..."
     
     if [[ ! -d "$NETBASICS_PATH" ]]; then
-        if ! $SUDO mkdir -p "$NETBASICS_PATH"; then
+        if ! "${SUDO[@]}" mkdir -p "$NETBASICS_PATH"; then
             log_error_and_exit "Failed to create directory $NETBASICS_PATH"
         fi
         log_message "Created directory: $NETBASICS_PATH"
@@ -84,7 +84,7 @@ create_directories() {
     fi
     
     if [[ ! -d "$LAUNCHDAEMONS_PATH" ]]; then
-        if ! $SUDO mkdir -p "$LAUNCHDAEMONS_PATH"; then
+        if ! "${SUDO[@]}" mkdir -p "$LAUNCHDAEMONS_PATH"; then
             log_error_and_exit "Failed to create directory $LAUNCHDAEMONS_PATH"
         fi
         log_message "Created directory: $LAUNCHDAEMONS_PATH"
@@ -109,7 +109,7 @@ stop_daemon() {
     
     if [[ -f "$daemon_path" ]]; then
         log_message "Stopping LaunchDaemon..."
-        if $SUDO launchctl bootout system "$daemon_path" 2>/dev/null; then
+        if "${SUDO[@]}" launchctl bootout system "$daemon_path" 2>/dev/null; then
             log_message "LaunchDaemon stopped successfully"
         else
             log_message "LaunchDaemon was not running or failed to stop (this is normal)"
@@ -125,7 +125,7 @@ start_daemon() {
     
     if [[ -f "$daemon_path" ]]; then
         log_message "Starting LaunchDaemon..."
-        if $SUDO launchctl bootstrap system "$daemon_path"; then
+        if "${SUDO[@]}" launchctl bootstrap system "$daemon_path"; then
             log_message "LaunchDaemon started successfully"
         else
             log_error_and_exit "Failed to start LaunchDaemon"
@@ -140,18 +140,18 @@ start_daemon() {
 #
 _deploy_files() {
     local wireless_dest="${NETBASICS_PATH}/${WIRELESS_SCRIPT}"
-    $SUDO cp "$WIRELESS_SCRIPT" "$wireless_dest" \
+    "${SUDO[@]}" cp "$WIRELESS_SCRIPT" "$wireless_dest" \
         || log_error_and_exit "Failed to copy $WIRELESS_SCRIPT to $wireless_dest"
-    $SUDO chmod 755 "$wireless_dest" \
+    "${SUDO[@]}" chmod 755 "$wireless_dest" \
         || log_error_and_exit "Failed to set permissions on $wireless_dest"
     log_message "Deployed: $wireless_dest"
 
     local daemon_dest="${LAUNCHDAEMONS_PATH}/${DAEMON_PLIST}"
-    $SUDO cp "$DAEMON_PLIST" "$daemon_dest" \
+    "${SUDO[@]}" cp "$DAEMON_PLIST" "$daemon_dest" \
         || log_error_and_exit "Failed to copy $DAEMON_PLIST to $daemon_dest"
-    $SUDO chown root:wheel "$daemon_dest" \
+    "${SUDO[@]}" chown root:wheel "$daemon_dest" \
         || log_error_and_exit "Failed to set ownership on $daemon_dest"
-    $SUDO chmod 644 "$daemon_dest" \
+    "${SUDO[@]}" chmod 644 "$daemon_dest" \
         || log_error_and_exit "Failed to set permissions on $daemon_dest"
     log_message "Deployed: $daemon_dest (root:wheel, 644)"
 
@@ -183,7 +183,7 @@ uninstall_components() {
     # Remove wireless script
     local wireless_dest="${NETBASICS_PATH}/${WIRELESS_SCRIPT}"
     if [[ -f "$wireless_dest" ]]; then
-        if ! $SUDO rm -f "$wireless_dest"; then
+        if ! "${SUDO[@]}" rm -f "$wireless_dest"; then
             log_error_and_exit "Failed to remove $wireless_dest"
         fi
         log_message "Removed: $wireless_dest"
@@ -194,7 +194,7 @@ uninstall_components() {
     # Remove LaunchDaemon plist
     local daemon_dest="${LAUNCHDAEMONS_PATH}/${DAEMON_PLIST}"
     if [[ -f "$daemon_dest" ]]; then
-        if ! $SUDO rm -f "$daemon_dest"; then
+        if ! "${SUDO[@]}" rm -f "$daemon_dest"; then
             log_error_and_exit "Failed to remove $daemon_dest"
         fi
         log_message "Removed: $daemon_dest"
@@ -204,7 +204,7 @@ uninstall_components() {
     
     # Remove directory if empty
     if [[ -d "$NETBASICS_PATH" ]] && [[ -z "$(ls -A "$NETBASICS_PATH")" ]]; then
-        if ! $SUDO rmdir "$NETBASICS_PATH"; then
+        if ! "${SUDO[@]}" rmdir "$NETBASICS_PATH"; then
             log_message "Warning: Failed to remove empty directory $NETBASICS_PATH"
         else
             log_message "Removed empty directory: $NETBASICS_PATH"
@@ -221,6 +221,7 @@ update_components() {
     log_message "Starting update..."
     configure_sudo
     validate_source_files
+    create_directories
     stop_daemon
     _deploy_files
     log_message "Update completed successfully"

--- a/wireless.sh
+++ b/wireless.sh
@@ -50,10 +50,7 @@ get_wired_interfaces() {
 #
 get_wifi_interfaces() {
     /usr/sbin/networksetup -listallhardwareports | \
-        tr '\n' ' ' | \
-        sed -e 's/Hardware Port:/\n/g' | \
-        grep Wi-Fi | \
-        awk '{print $3}'
+        awk '/^Hardware Port: Wi-Fi$/{getline; print $2}'
 }
 
 #
@@ -69,8 +66,7 @@ get_interface_ip() {
     ip_result=$(ifconfig "$interface" 2>/dev/null | \
         grep -E 'inet [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | \
         grep -E -v '127\.0\.0\.1|169\.254\.' | \
-        awk '{print $2}' | \
-        head -1)
+        awk 'NR==1{print $2; exit}')
     echo "$ip_result"
 }
 


### PR DESCRIPTION
## Changes

### #69 — SIGPIPE fix in `get_interface_ip`
Replaced `awk '{print $2}' | head -1` with `awk 'NR==1{print $2; exit}'`. When `head -1` exits after the first line, `awk` receives SIGPIPE → exit 141 → `pipefail` kills the caller. Merging both into one awk command eliminates the pipe entirely.

### #70 — `update_components` missing `create_directories`
Added a `create_directories` call before `stop_daemon` in `update_components()`, mirroring `install_components`. Without it, updating on a fresh machine (or after manual cleanup) fails with a missing-directory error.

### #71 — `SUDO` array (SC2086)
Converted `SUDO=""`/`SUDO="sudo"` to `SUDO=()`/`SUDO=(sudo)` and updated all 12 callsites from `$SUDO cmd` to `"${SUDO[@]}" cmd`. Silences SC2086 and correctly handles paths with spaces.

### #72 — Cleaner `get_wifi_interfaces`
Replaced the five-stage `tr | sed | grep | awk` pipeline with a single `awk '/^Hardware Port: Wi-Fi$/{getline; print $2}'`. Simpler, fewer processes, no intermediate string mangling.

## Test results
- shellcheck: ✅ clean
- BATS: 45/45 passed

Closes #69, #70, #71, #72